### PR TITLE
Fix bug where available was showing up twice in a row

### DIFF
--- a/src/components/sections/SectionInfo.vue
+++ b/src/components/sections/SectionInfo.vue
@@ -28,7 +28,7 @@
             this.$store.state.courseSizes[section.crn]
           )
         }}
-        available. Check SIS for more up to date information.
+        . Check SIS for more up to date information.
       </div>
       <template v-slot:modal-footer="{ ok }">
         <b-button variant="primary" @click="ok()">

--- a/src/components/sections/Sections.vue
+++ b/src/components/sections/Sections.vue
@@ -95,7 +95,7 @@
             :title="
               'There are ' +
               formatCourseSize(section.crn, courseSizes) +
-              ' available. Check SIS for more up to date information.'
+              '. Check SIS for more up to date information.'
             "
             >{{ formatCourseSize(section.crn) }}</span
           >


### PR DESCRIPTION
The 'Seats' section would read as:
Seats:
There are min/max seats available available...

This commit removes the duplicate available

