### PR TITLE
lint: fix errors from eslint upgrade

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: Lint
-on: push
+on: [push, pull_request]
 jobs:
   lint:
     name: Lint

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -92,7 +92,8 @@ export default new Vuex.Store({
           const parser = new DOMParser();
           const xmlDoc = parser.parseFromString(data, "text/xml");
 
-          const liveData: { [id: string]: CourseSize | {} } = {};
+          // @ts-expect-error: liveData
+          const liveData: { [id: string]: CourseSize | DummyVal } = {};
           const courses = xmlDoc.getElementsByTagName("SECTION");
           for (let i = 0; i < courses.length; i++) {
             liveData[courses[i].attributes[0].nodeValue || ""] = {};

--- a/src/views/Department.vue
+++ b/src/views/Department.vue
@@ -22,6 +22,7 @@ import { mapGetters } from "vuex";
 import { BSpinner } from "bootstrap-vue";
 
 import CourseCard from "../components/CourseCard.vue";
+import { Course } from "../typings";
 
 @Component({
   components: {
@@ -35,9 +36,10 @@ import CourseCard from "../components/CourseCard.vue";
 export default class Department extends Vue {
   @Prop() code!: string;
 
-  get department() {
-    // @ts-expect-error
+  get department(): Department {
+    // @ts-expect-error: value exists
     if (!this.departmentsInitialized) {
+      // @ts-expect-error: uses {} type
       return {};
     }
 
@@ -46,11 +48,11 @@ export default class Department extends Vue {
         return dept;
       }
     }
-
+    // @ts-expect-error: uses {} type
     return {};
   }
 
-  get formattedDept() {
+  get formattedDept(): Department {
     for (const schoolName in this.$store.state.schools) {
       const school = this.$store.state.schools[schoolName];
 
@@ -61,14 +63,15 @@ export default class Department extends Vue {
       }
     }
 
+    // @ts-expect-error: uses {} type
     return {};
   }
 
-  get courses() {
+  get courses(): Course[] {
     return this.department.courses;
   }
 
-  get name() {
+  get name(): string {
     return this.formattedDept.name;
   }
 }

--- a/src/views/Prerequisites.vue
+++ b/src/views/Prerequisites.vue
@@ -229,7 +229,7 @@ export default class Prerequisites extends Vue {
   tabNumber = 0;
   file = null;
 
-  formatCourse(value: string) {
+  formatCourse(value: string): string {
     return value
       .toUpperCase()
       .replace("_", "-")
@@ -237,18 +237,18 @@ export default class Prerequisites extends Vue {
       .substring(0, 9);
   }
 
-  addCourse() {
+  addCourse(): void {
     // @ts-expect-error: no u typescript, this does exist
     if (this.verifyNewCourse) {
       this.$store.commit("prerequisites/addPriorCourse", this.newCourse);
     }
   }
 
-  removeCourse(course: string) {
+  removeCourse(course: string): void {
     this.$store.commit("prerequisites/removePriorCourse", course);
   }
 
-  importTranscript() {
+  importTranscript(): void {
     const store = this.$store;
     const bvModal = this.$bvModal;
     const importedTranscript = scrapeTranscript("transcriptFileUpload");
@@ -258,7 +258,7 @@ export default class Prerequisites extends Vue {
         console.log(err);
         bvModal.show("transcriptImportModal");
       })
-      // @ts-expect-error
+      // @ts-expect-error: TBD
       .then(function (transcript) {
         for (const term of transcript.terms.concat(
           transcript.inProgressTerms

--- a/vue.config.js
+++ b/vue.config.js
@@ -5,7 +5,7 @@ module.exports = {
     themeColor: "#DCC308",
     msTileColor: "#DCC308",
     manifestOptions: {
-      background_color: "#DCC308", // eslint-disable-line @typescript-eslint/camelcase
+      background_color: "#DCC308",
     },
     name: "QuACS",
     workboxOptions: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,7 +30,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@fortawesome/fontawesome-common-types@^0.2.29", "@fortawesome/fontawesome-common-types@^0.2.30":
+"@fortawesome/fontawesome-common-types@^0.2.30":
   version "0.2.30"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.30.tgz#2f1cc5b46bd76723be41d0013a8450c9ba92b777"
   integrity sha512-TsRwpTuKwFNiPhk1UfKgw7zNPeV5RhNp2Uw3pws+9gDAkPGKrtjR1y2lI3SYn7+YzyfuNknflpBA1LRKjt7hMg==


### PR DESCRIPTION
This change fixes various type errors from the previous upgrade (see #75,76)
by either correcting where obvious and easy, or temporarily whitelisting
the new violations.

This change also enables the "lint" action for PRs, blocking them
from being merge-able to ensure stability on master.