### PR TITLE
schedule: add support for weekend (Saturday) courses

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -15,7 +15,7 @@
     <div class="calendar-grid">
       <div
         class="grid-day"
-        v-for="day of days"
+        v-for="day in getDays()"
         :key="day.short"
         :style="{ width: dayWidth + '%' }"
       >
@@ -73,7 +73,6 @@ import { mapGetters } from "vuex";
 
 @Component({
   computed: {
-    days: () => DAYS,
     ...mapGetters("settings", ["isMilitaryTime"]),
   },
 })
@@ -82,6 +81,17 @@ export default class Calendar extends Vue {
   readonly startTime = 420;
   readonly endTime = 1320;
   readonly totalHeight = 650;
+
+  getDays(): Day[] {
+    const hasWeekend =
+      this.sessionsOnDay({ name: "Saturday", short: "S" }).length > 0;
+
+    if (hasWeekend) {
+      return DAYS;
+    }
+
+    return DAYS.slice(0, 5);
+  }
 
   // get crns() {
   //   if (this.$route.query.crns === undefined) {
@@ -95,7 +105,7 @@ export default class Calendar extends Vue {
   }
 
   get dayWidth(): number {
-    return 100 / DAYS.length;
+    return 100 / this.getDays().length;
   }
 
   get hourHeight(): number {

--- a/src/components/sections/Sections.vue
+++ b/src/components/sections/Sections.vue
@@ -8,7 +8,11 @@
         v-on:keyup.enter="toggleAll()"
       >
         <th style="width: 100%;">Toggle all sections</th>
-        <th v-for="day in days" v-bind:key="day" class="week-day desktop-only">
+        <th
+          v-for="day in getDays()"
+          v-bind:key="day"
+          class="week-day desktop-only"
+        >
           {{ day }}
         </th>
       </tr>
@@ -101,7 +105,7 @@
           >
           <!-- Mobile times -->
           <div class="mobile-only">
-            <template v-for="day in days">
+            <template v-for="day in getDays()">
               <!-- TODO: fix different instructors for same timeslot -->
               <span
                 v-for="session in getSessions(section, day)"
@@ -122,7 +126,11 @@
           <!-- End mobile times -->
         </td>
         <!-- Desktop times -->
-        <td v-for="day in days" v-bind:key="day" class="time-cell desktop-only">
+        <td
+          v-for="day in getDays()"
+          v-bind:key="day"
+          class="time-cell desktop-only"
+        >
           <!-- TODO: fix different instructors for same timeslot -->
           <span
             v-for="timeslot in spaceOutTimeslots(
@@ -182,7 +190,7 @@ import { VBTooltip } from "bootstrap-vue";
 })
 export default class Section extends Vue {
   @Prop() readonly course!: Course;
-  days = ["M", "T", "W", "R", "F"];
+  days = [] as string[];
   conflicts: { [crn: number]: boolean } = {};
 
   mounted(): void {
@@ -193,6 +201,29 @@ export default class Section extends Vue {
         }
       );
     }
+  }
+
+  getDays(): string[] {
+    // Don't compute the days array again
+    if (this.days.length > 0) {
+      return this.days;
+    }
+
+    // By default, we list all 5 weekdays
+    this.days = ["M", "T", "W", "R", "F"];
+
+    // Check to see if the class has a weekend entry
+    const weekendTime = (timeslot: Timeslot) => timeslot.days.includes("S");
+    const hasWeekend = this.course.sections.some((section) =>
+      section.timeslots.some(weekendTime)
+    );
+
+    // Only display saturday if necessary
+    if (hasWeekend) {
+      this.days.push("S");
+    }
+
+    return this.days;
   }
 
   toggleSelection(

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -22,6 +22,10 @@ export const DAYS: Day[] = [
     name: "Friday",
     short: "F",
   },
+  {
+    name: "Saturday",
+    short: "S",
+  },
 ];
 
 export function getSessions() {


### PR DESCRIPTION
The fall 2020 semester brought a depressing addition of a class,
BIOL-4720: Molecular Biology Lab, which has a section that
meets on a Saturday.

This change adds support for QuACS being able to support
courses with Saturday meeting times in both the section view
and calendar / schedule overview.

Per request, the section cards will only display weekend days
iff. a course has a timeslot on a weekend.