### PR TITLE
dependabot.yml hotfix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
   ignored_updates:
     - match:
         dependency_name: "*eslint*"
+
 - package-ecosystem: cargo
   directory: "/src/quacs-rs"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  ignored_updates:
-    - match:
-        dependency_name: "*eslint*"
 
 - package-ecosystem: cargo
   directory: "/src/quacs-rs"


### PR DESCRIPTION
It didn't like the ignored_updates section anymore, so I just removed it as we've successfully handled eslint updates in the past.