### PR TITLE
schedule: add front-end support for sunday classes

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -84,7 +84,9 @@ export default class Calendar extends Vue {
 
   getDays(): Day[] {
     const hasWeekend =
-      this.sessionsOnDay({ name: "Saturday", short: "S" }).length > 0;
+      this.sessionsOnDay({ name: "Saturday", short: "S" }).length +
+        this.sessionsOnDay({ name: "Sunday", short: "U" }).length >
+      0;
 
     if (hasWeekend) {
       return DAYS;

--- a/src/components/sections/Sections.vue
+++ b/src/components/sections/Sections.vue
@@ -213,14 +213,16 @@ export default class Section extends Vue {
     this.days = ["M", "T", "W", "R", "F"];
 
     // Check to see if the class has a weekend entry
-    const weekendTime = (timeslot: Timeslot) => timeslot.days.includes("S");
+    const weekendTime = (timeslot: Timeslot) =>
+      timeslot.days.includes("S") || timeslot.days.includes("U");
     const hasWeekend = this.course.sections.some((section) =>
       section.timeslots.some(weekendTime)
     );
 
-    // Only display saturday if necessary
+    // Only display weekend days if necessary
     if (hasWeekend) {
       this.days.push("S");
+      this.days.push("U");
     }
 
     return this.days;


### PR DESCRIPTION
Fall 2020 brought us the suprise of Saturday classes, Spring 2021 brings us the suprise of Sunday classes ('U').
This commit leverages the existing infrastructure of only including saturday/sunday on the course times if the class has a weekend timeslot (unlikely) to reduce clutter.