### PR TITLE
ci: bump setup-node to latest version to avoid major breakages

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node.js for use with actions
-        uses: actions/setup-node@v1.1.0
+        uses: actions/setup-node@v1.4.4
         with:
-          version:  12.x
+          version:  15.x
 
       - name: Checkout branch
         uses: actions/checkout@v2

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node.js for use with actions
-        uses: actions/setup-node@v1.1.0
+        uses: actions/setup-node@v1.4.4
         with:
-          version:  12.x
+          version:  15.x
 
       - name: Checkout branch
         uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node.js for use with actions
-        uses: actions/setup-node@v1.1.0
+        uses: actions/setup-node@v1.4.4
         with:
-          version:  12.x
+          version:  15.x
 
       - name: Checkout branch
         uses: actions/checkout@v2


### PR DESCRIPTION
See this warning: 
![image](https://user-images.githubusercontent.com/5902494/99291265-89695680-280d-11eb-9c3d-fa9ba58c5808.png)
