### PR TITLE
Fix issue with ics export not working in google calendar as well as fix timezone issues

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -22,6 +22,7 @@
     "file-saver": "^2.0.5",
     "fuse.js": "^6.4.6",
     "ics": "^2.26.2",
+    "moment-timezone": "^0.5.32",
     "register-service-worker": "^1.7.2",
     "simple-web-worker": "^1.2.0",
     "vue": "^2.6.12",

--- a/site/src/views/Schedule.vue
+++ b/site/src/views/Schedule.vue
@@ -109,6 +109,7 @@ import CourseCard from "@/components/CourseCard.vue";
 import { EventAttributes, createEvents } from "ics";
 import { saveAs } from "file-saver";
 import { shortSemToLongSem } from "@/utilities";
+import moment from "moment-timezone";
 
 // eslint-disable-next-line
 declare const umami: any; // Not initialized here since it's declared elsewhere
@@ -302,35 +303,62 @@ export default class Schedule extends Vue {
               recurrenceRule += year;
               recurrenceRule += timeslot.dateEnd.replace("/", "");
 
-              // Make a js date that starts on the first day of the semester
-              // need to add hours/min/sec to make sure it gets the correct day
-              const month = timeslot.dateStart.split("/")[0];
-              const day = timeslot.dateStart.split("/")[1];
-              let start = new Date(`${year}-${month}-${day} 1:0:0`);
+              // Make a js dates for start time
+              const monthStart = timeslot.dateStart.split("/")[0];
+              const dayStart = timeslot.dateStart.split("/")[1];
+              const hourStart = Math.floor(timeslot.timeStart / 100);
+              const minStart = timeslot.timeStart % 100;
+              let startJSDate = new Date(
+                `${year}-${monthStart}-${dayStart} ${hourStart}:${minStart}:0`
+              );
 
-              //Find the first day after the semester starts that has this section
-              //For example if the semster starts on a monday, but the section is on wednesday
+              // Make a js dates for end time
+              const monthEnd = timeslot.dateStart.split("/")[0];
+              const dayEnd = timeslot.dateStart.split("/")[1];
+              const hourEnd = Math.floor(timeslot.timeEnd / 100);
+              const minEnd = timeslot.timeEnd % 100;
+              let endJSDate = new Date(
+                `${year}-${monthEnd}-${dayEnd} ${hourEnd}:${minEnd}:0`
+              );
+
+              // Find the first day after the semester starts that has this section
+              // For example if the semster starts on a monday, but the section is on wednesday
               // then move the date up to the next wednesday
-              while (!timeslot.days.includes(dayNumToLetter[start.getDay()])) {
-                start.setDate(start.getDate() + 1);
+              while (
+                !timeslot.days.includes(dayNumToLetter[startJSDate.getDay()])
+              ) {
+                startJSDate.setDate(startJSDate.getDate() + 1);
+                endJSDate.setDate(endJSDate.getDate() + 1);
               }
+
+              // parse with NY time, and then convert to UTC
+              // TODO convert this to using a config file where you can set the default timezone
+              // Code based off here https://github.com/adamgibbons/ics/issues/126#issuecomment-586352771
+              const startMomentDate = moment
+                .tz(startJSDate, "America/New_York")
+                .utc();
+              const endMomentDate = moment
+                .tz(endJSDate, "America/New_York")
+                .utc();
 
               events.push({
                 title: section.title,
                 start: [
-                  Number(year),
-                  start.getMonth() + 1,
-                  start.getDate(),
-                  Math.floor(timeslot.timeStart / 100),
-                  timeslot.timeStart % 100,
+                  startMomentDate.get("year"),
+                  startMomentDate.get("month") + 1,
+                  startMomentDate.get("date"),
+                  startMomentDate.get("hour"),
+                  startMomentDate.get("minute"),
                 ],
+                startInputType: "utc",
                 end: [
-                  Number(year),
-                  Number(timeslot.dateStart.split("/")[0]),
-                  Number(timeslot.dateStart.split("/")[1]),
-                  Math.floor(timeslot.timeEnd / 100),
-                  timeslot.timeEnd % 100,
+                  endMomentDate.get("year"),
+                  endMomentDate.get("month") + 1,
+                  endMomentDate.get("date"),
+                  endMomentDate.get("hour"),
+                  endMomentDate.get("minute"),
                 ],
+                endInputType: "utc",
                 location:
                   timeslot.location !== "TBA" ? timeslot.location : undefined,
                 recurrenceRule,

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -5074,6 +5074,18 @@ mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+moment-timezone@^0.5.32:
+  version "0.5.32"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.32.tgz#db7677cc3cc680fd30303ebd90b0da1ca0dfecc2"
+  integrity sha512-Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0":
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
This PR fixes 2 issues

1. The ics export would sometimes cause issue in google calendar and default timeblocks to an hour
2. if you are not in rpi time, the export button would assume you were causing timezone issues


