### PR TITLE
Add check to make sure umami.js downloads correctly

### DIFF
--- a/site/scripts/build_entry.sh
+++ b/site/scripts/build_entry.sh
@@ -2,7 +2,9 @@
 
 # Update Umami
 echo Updating Umami
-curl https://umami.quacs.org/umami.js >public/umami.js || exit 1
+curl https://umami.quacs.org/umami.js > public/umami.js || exit 1
+# If umami crashes, the file will contain an nginx error instead of the js code
+if cat public/umami.js | grep -q nginx; then exit 1; fi
 
 # Update our local dependencies (quacs-rs), or clone if possible
 echo Retrieving latest quacs-data


### PR DESCRIPTION
If umami crashes, then instead of downloading umami.js it will download an nginx error. This checks for that and exits the build process.