### PR TITLE
prereq_graph: fix non-determinism in json generation

### DIFF
--- a/scrapers/prerequisites_graph/main.py
+++ b/scrapers/prerequisites_graph/main.py
@@ -70,7 +70,7 @@ def get_prereq_course_ids(prereqs):
     if typ == "course":
         return [prereqs["course"]]
     if typ in ["and", "or"]:
-        return list(
+        return sorted(
             set(
                 functools.reduce(
                     operator.add, map(get_prereq_course_ids, prereqs["nested"]), []


### PR DESCRIPTION
See the prereq_graph.json history for context https://github.com/quacs/quacs-data/commits/master/prereq_graph.json

This change introduces a sorted order for ("and","or") prereqs. By default, python's sets are unordered, making their ordering non-deterministic. Instead of building a list from the set using list(), call sorted() to ensure a deterministic order