### PR TITLE
CI: Remove no-longer-used node-canvas dependencies

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -32,9 +32,6 @@ jobs:
           path: "site/gh-pages-site"
           token: ${{ secrets.QUACS_TOKEN }}
 
-      - name: Install Ubuntu dependencies for node-canvas
-        run: sudo apt-get -y install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
-
       - name: Clean install dependencies
         working-directory: ./site
         run: yarn install --frozen-lockfile

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -13,9 +13,6 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v2
 
-      - name: Install Ubuntu dependencies for node-canvas
-        run: sudo apt-get -y install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
-
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,9 +18,6 @@ jobs:
       - name: Update submodules
         run: git submodule update --remote --recursive
 
-      - name: Install Ubuntu dependencies for node-canvas
-        run: sudo apt-get -y install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
-
       - name: Clean install dependencies
         working-directory: ./site
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
The vue-visjs package no longer depends on node-canvas, so the CI doesn't need to install dependencies for it.

https://github.com/sjmallon/vue-visjs/issues/7