### PR TITLE
Switch updated date+time from meta.json to use the github api

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -260,10 +260,6 @@ jobs:
         with:
           path: scrapers
 
-      - name: Generate meta json file
-        working-directory: ./scrapers
-        run: echo {\"last_updated\":\"$(date --iso-8601=seconds -u)\"} > data/meta.json
-
       - name: Commit new data
         working-directory: ./scrapers
         run: |
@@ -285,7 +281,12 @@ jobs:
 
           git add .
 
-          git commit -m "$(date -u)"
+          git commit -m "$(date -u)" || exit 0
+
+          echo {\"last_updated\":\"$(date --iso-8601=seconds -u)\"} > data/meta.json
+          git add meta.json
+          
+          git commit -a --amend --no-edit
           git push --force
 
       - name: Deploy updated website

--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ The following commands should be run within the `site/` directory:
 yarn install
 ```
 
-You'll also need to install Rust and `wasm-pack` to build the WebAssembly components of the website.  Instructions for installing `wasm-pack` can be found [here](https://rustwasm.github.io/wasm-pack/installer/).
+You'll also need to install:
+* Rust and `wasm-pack` to build the WebAssembly components of the website.  Instructions for installing `wasm-pack` can be found [here](https://rustwasm.github.io/wasm-pack/installer/).
+
+* `jq` to parse json files. Instructions for installing `jq` can be found [here](https://stedolan.github.io/jq/download/).
 
 ### Compiles and hot-reloads for development
 ```

--- a/site/scripts/build_entry.sh
+++ b/site/scripts/build_entry.sh
@@ -7,8 +7,10 @@ curl https://umami.quacs.org/umami.js > public/umami.js || exit 1
 if cat public/umami.js | grep -q nginx; then exit 1; fi
 
 echo Getting time of last data scraped
-curl "https://api.github.com/repos/quacs/quacs/actions/runs?per_page=100&event=schedule" | jq 'first(.workflow_runs[] | select(.conclusion=="success")) | .updated_at' > src/store/data/latest_scrape.json
+curl "https://api.github.com/repos/quacs/quacs/actions/runs?per_page=100&event=schedule" > temp.json
+jq 'first(.workflow_runs[] | select(.conclusion=="success")) | .updated_at' temp.json > src/store/data/latest_scrape.json
 printf '%s%s%s' "{\"last_updated\":" "$(cat src/store/data/latest_scrape.json)" "}" > src/store/data/latest_scrape.json
+rm temp.json
 
 # Update our local dependencies (quacs-rs), or clone if possible
 echo Retrieving latest quacs-data

--- a/site/scripts/build_entry.sh
+++ b/site/scripts/build_entry.sh
@@ -6,6 +6,10 @@ curl https://umami.quacs.org/umami.js > public/umami.js || exit 1
 # If umami crashes, the file will contain an nginx error instead of the js code
 if cat public/umami.js | grep -q nginx; then exit 1; fi
 
+echo Getting time of last data scraped
+curl "https://api.github.com/repos/quacs/quacs/actions/runs?per_page=100&event=schedule" | jq 'first(.workflow_runs[] | select(.conclusion=="success")) | .updated_at' > src/store/data/latest_scrape.json
+printf '%s%s%s' "{\"last_updated\":" "$(cat src/store/data/latest_scrape.json)" "}" > src/store/data/latest_scrape.json
+
 # Update our local dependencies (quacs-rs), or clone if possible
 echo Retrieving latest quacs-data
 git -C src/store/data pull || git clone https://github.com/quacs/quacs-data --depth=1 src/store/data || exit 1

--- a/site/src/App.vue
+++ b/site/src/App.vue
@@ -229,7 +229,7 @@ export default class App extends Vue {
   get lastUpdated(): string {
     let timeDifference =
       (new Date().getTime() -
-        new Date(this.$store.state.dataStats.last_updated).getTime()) /
+        new Date(this.$store.state.updatedTime).getTime()) /
       1000;
     const seconds = Math.floor(timeDifference % 60);
     timeDifference = timeDifference / 60;

--- a/site/src/store/index.ts
+++ b/site/src/store/index.ts
@@ -16,6 +16,7 @@ import Vuex from "vuex";
 const SCHOOLS_JSON = require(`./data/semester_data/${process.env.VUE_APP_CURR_SEM}/schools.json`);
 
 import DATA_STATS_JSON from "./data/meta.json";
+import LATEST_SCRAPE from "./data/latest_scrape.json";
 import PREREQ_GRAPH_JSON from "./data/prereq_graph.json";
 
 import settings from "./modules/settings";
@@ -32,6 +33,7 @@ export default new Vuex.Store({
       depts: { code: string; name: string }[];
     }[],
     dataStats: DATA_STATS_JSON as { last_updated: string },
+    updatedTime: LATEST_SCRAPE.last_updated,
     departments: [] as Department[], // asynchronously loaded
     catalog: {} as { [id: string]: CatalogCourse }, // asynchronously loaded
     prerequisitesData: {} as { [id: string]: PrerequisiteJSON }, // asynchronously loaded


### PR DESCRIPTION
This switches the website to use the latest successful github action scrape run when building. This means that we dont need to update meta.json if nothing changes.

This addresses the issues that were brought up when trying to merge this pr https://github.com/quacs/quacs-data/pull/4

Note that I left meta.json as is because we still plan on using it for other stuff so it makes sense to still exist