### PR TITLE
scrape: ensure rsync doesn't raise exit status 23

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -355,13 +355,13 @@ jobs:
 
           cp prereq_graph/prereq_graph.json data/
 
-          rsync -avzh --ignore-missing-args faculty/faculty.json data
+          rsync -avzh --ignore-missing-args faculty/faculty.json data || true
 
-          rsync -avzh --ignore-missing-args hass_pathways/hass_pathways.json data
+          rsync -avzh --ignore-missing-args hass_pathways/hass_pathways.json data || true
 
-          rsync -avzh --ignore-missing-args transfer/transfer.json data
+          rsync -avzh --ignore-missing-args transfer/transfer.json data || true
 
-          rsync -avzh --ignore-missing-args transfer_guides/ data/transfer_guides/
+          rsync -avzh --ignore-missing-args transfer_guides/ data/transfer_guides/ || true
 
           cd data
           git config user.name "QuACS" && git config user.email "github@quacs.org"


### PR DESCRIPTION
rsync will raise this in the event that a partial transfer occurs - the || true will ignore this.