### PR TITLE
scrape: enforce 1 minute timeout on HASS pathway scraper

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -214,6 +214,7 @@ jobs:
   scrape-hass-pathways:
     name: Scrape HASS pathways
     runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2

--- a/scrapers/hass_pathways_scraper/main.py
+++ b/scrapers/hass_pathways_scraper/main.py
@@ -8,6 +8,7 @@ and the data is very unstructured so this doesn't work super well.
 
 import json
 import requests
+import sys
 from bs4 import BeautifulSoup
 
 
@@ -97,12 +98,15 @@ def parse_pathways(soup):
 
 def main():
     """Download the pathways page and print a parsed json"""
+    print("Beginning HASS pathway scraping", file=sys.stderr)
     r = requests.get(
         "https://info.rpi.edu/hass-pathways/pathways-topics/",
         headers={"User-Agent": "Mozilla"},  # It 403 errors without this
     )
+    print("Retrieved pathways..", file=sys.stderr)
     soup = BeautifulSoup(r.text)
     pathways = parse_pathways(soup)
+    print("Pathways parsed successfully..", file=sys.stderr)
     print(json.dumps(pathways, indent=4, sort_keys=True))
 
 


### PR DESCRIPTION
Example runtime: https://github.com/quacs/quacs/runs/2188485099?check_suite_focus=true

The hass scraper has run into an issue where it will proceed to run indefinitely (until the 6 hour timeout hits) during some of its runs. It has only been reproducable on Github Actions.

This change enforces a 10 minute timeout to ensure we aren't hoarding resources while the root cause is determined.

Debug prints have been added to the scraper to help determine the root cause.