### PR TITLE
schedule: fix ICS exporting, resolves #269

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -22,7 +22,6 @@
     "file-saver": "^2.0.5",
     "fuse.js": "^6.4.6",
     "ics": "^2.27.0",
-    "moment-timezone": "^0.5.33",
     "register-service-worker": "^1.7.2",
     "simple-web-worker": "^1.2.0",
     "tslib": "^2.1.0",


### PR DESCRIPTION
Resolves #269 
- Removes moment.js dependency, no longer needed.
- Manually update the DTSTART/DTEND fields to pin the timezone to America\New_York instead of UTC. This addresses issues with daylight savings time shifting the times. Calendar apps should be able to do the necessary conversions.