### PR TITLE
Revert "quacs-rs: force syn=1.0.65 to address site build failures"

### DIFF
--- a/site/src/quacs-rs/Cargo.toml
+++ b/site/src/quacs-rs/Cargo.toml
@@ -19,7 +19,6 @@ lazy_static = "^1.4.0"
 phf = { version = "^0.8", features = ["macros"] }
 wasm-bindgen = "^0.2"
 web-sys = { version = "^0.3.40", features = ["console"] }
-syn = "=1.0.65"
 
 console_error_panic_hook = { version = "0.1.6", optional = true }
 


### PR DESCRIPTION
Reverts quacs/quacs#425

No longer needed since we have dbf3cff5e161d9de5a63cf2d12aef8a3aef7184e