### PR TITLE
Support for closed indicators

### DIFF
--- a/scrapers/catalog_scraper/main.py
+++ b/scrapers/catalog_scraper/main.py
@@ -25,7 +25,7 @@ async def get_years() -> List[Tuple[str, str, str]]:
             homepage_text = await homepage.text()
             home_soup = BeautifulSoup(homepage_text.encode("utf8"), "lxml")
             dropdown_entries = home_soup.find(
-                "select", {"title": "Select a Catalog"}
+                "select", {"name": "catalog"}
             ).findChildren("option", recursive=False)
 
             dropdown_mapped = map(lambda x: (x["value"], x.string), dropdown_entries)

--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -282,7 +282,6 @@ with requests.Session() as s:  # We purposefully don't use aiohttp here since SI
                     credit_max = float(getContent(td[6]).split("-")[1])
 
                 section_data = {
-                    "closed":getContentFromChild(td[0], 'abbr'),
                     "crn": int(getContentFromChild(td[1], "a")),
                     "subj": getContent(td[2]),
                     "crse": int(getContent(td[3])),
@@ -303,6 +302,11 @@ with requests.Session() as s:  # We purposefully don't use aiohttp here since SI
                     "attribute": getContent(td[22]) if 22 < len(td) else "",
                     "timeslots": [timeslot_data],
                 }
+
+                status = getContentFromChild(td[0], "abbr")
+
+                if status in ["C", "NR"]:
+                    section_data["closed"] = True
 
                 if (
                     section_data["subj"] == last_subject

--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -282,7 +282,7 @@ with requests.Session() as s:  # We purposefully don't use aiohttp here since SI
                     credit_max = float(getContent(td[6]).split("-")[1])
 
                 section_data = {
-                    # "select":getContentFromChild(td[0], 'abbr'),
+                    "closed":getContentFromChild(td[0], 'abbr'),
                     "crn": int(getContentFromChild(td[1], "a")),
                     "subj": getContent(td[2]),
                     "crse": int(getContent(td[3])),

--- a/site/src/components/CourseCard.vue
+++ b/site/src/components/CourseCard.vue
@@ -103,6 +103,15 @@
             Hybrid Course
           </span>
         </span>
+
+        <span v-if="this.fullSections != 2 && closed">
+          <span class="padding-left prerequisiteError prerequisiteBkgError">
+            <font-awesome-icon
+              :icon="['fas', 'exclamation-triangle']"
+            ></font-awesome-icon>
+            Closed
+          </span>
+        </span>
       </div>
       <!-- <br> -->
       {{ getDescription(course.subj, course.crse) }}
@@ -227,6 +236,12 @@ export default class CourseCard extends Vue {
 
   get hybrid(): boolean {
     return this.course.sections[0].attribute.includes("Hybrid");
+  }
+
+  get closed(): boolean {
+    return this.course.sections.every(function (section) {
+      return section.closed;
+    });
   }
 
   getDescription(subject: string, code: string): string {

--- a/site/src/components/sections/SectionInfo.vue
+++ b/site/src/components/sections/SectionInfo.vue
@@ -39,6 +39,16 @@
         <div class="font-weight-bold">Visualize Prerequisites:</div>
         <PrereqGraph :course="courseCode"></PrereqGraph>
       </template>
+      <template v-if="section.closed">
+        <b>This section is currently closed.</b>
+        In order to register, you must submit a signed
+        <a
+          href="https://www.rpi.edu/dept/srfs/AuthorizationFrm.pdf"
+          target="_blank"
+          >override form</a
+        >
+        to the registrar.
+      </template>
     </b-modal>
   </div>
 </template>

--- a/site/src/components/sections/Sections.vue
+++ b/site/src/components/sections/Sections.vue
@@ -75,7 +75,7 @@
           <span
             class="padding-left prerequisiteError"
             :class="{
-              hidden: !(section.rem <= 0),
+              hidden: !(section.rem <= 0) || section.closed,
             }"
             v-on:click.stop.prevent
             v-on:keyup.enter.stop.prevent
@@ -87,6 +87,22 @@
             ></font-awesome-icon>
             Full Section</span
           >
+
+          <span
+            class="padding-left prerequisiteError"
+            :class="{
+              hidden: !section.closed,
+            }"
+            v-on:click.stop.prevent
+            v-on:keyup.enter.stop.prevent
+            @click="showSectionModal(section.crn)"
+            @keyup.enter="showSectionModal(section.crn)"
+          >
+            <font-awesome-icon
+              :icon="['fas', 'exclamation-triangle']"
+            ></font-awesome-icon>
+            Closed
+          </span>
           <span title="Professor(s)">
             | {{ section.timeslots[0].instructor }} |
           </span>

--- a/site/src/typings.ts
+++ b/site/src/typings.ts
@@ -28,6 +28,7 @@ export interface CourseSection {
 
   timeslots: Timeslot[];
   attribute: string;
+  closed: boolean;
 }
 
 export interface Course {


### PR DESCRIPTION
This resolves #271.

From commmit 96e9760:
"This commit enables support for scraping and displaying course closed indicators (defined as 'NR' - Not available for registration  or 'C' - closed on the sis view).

For the QuACS UI, a course is defined as closed when the following conditions are met:
1. All sections have 'closed':true set.
2. The course is not full.

This avoids redundant labeling since for all intents-and-purposes a full course is a closed course.
For sections, the logic is similar except the individual section attribute and size is checked."