### PR TITLE
scrape: don't run deploy hook if we didn't commit

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -392,12 +392,6 @@ jobs:
           git add data/meta.json
           git commit --amend --no-edit
           git push --force
-
-      - name: Deploy updated website
-        working-directory: ./scrapers
-        if: ${{ success() }}
-        run: |
-          cd data
           curl -H "Accept: application/vnd.github.everest-preview+json" \
               -H "Authorization: token ${{ secrets.GITHUBTOKEN }}" \
               --request POST \


### PR DESCRIPTION
Github actions will continue to run following steps if we exited prematurely with success. This works around that by merging the deployment step into the commit step.