### PR TITLE
ci: fix race condition in deployment

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - staging
+concurrency: site-deploy-lock
 jobs:
   gh-pages-deploy:
     name: Deploying to gh-pages


### PR DESCRIPTION
This change introduces a lock in the gh-pages-deploy action. This prevents site rebuilds from intefering scraping and vice-versa.