### PR TITLE
scrapers: pin versions in requirements.txt

### DIFF
--- a/scrapers/requirements.txt
+++ b/scrapers/requirements.txt
@@ -1,6 +1,6 @@
-beautifulsoup4
-tqdm
-requests
-python-dotenv
-lxml
-aiohttp
+aiohttp==3.7.4.post0
+beautifulsoup4==4.9.3
+lxml==4.6.3
+python-dotenv==0.17.1
+requests==2.25.1
+tqdm==4.60.0


### PR DESCRIPTION
Updates to the python dependencies in the scrapers will now be managed by dependabot. This helps ensure a more deterministic CI process.

A notable short coming is we have no good way to do correctness testing of scraper changes until the next scraping run; however, if we start getting sudden CI failures we can look to see if dependabot made any changes.