### PR TITLE
schedule: fix regression in schedule generation, resolves #613

### DIFF
--- a/site/src/views/Schedule.vue
+++ b/site/src/views/Schedule.vue
@@ -367,7 +367,7 @@ export default class Schedule extends Vue {
             date.getMonth() + 1,
             date.getDate(),
             date.getHours(),
-            date.getSeconds(),
+            date.getMinutes(),
           ];
         };
         // TODO convert this to using a config file where you can set the default timezone


### PR DESCRIPTION
When simplifying the ics logic as part of https://github.com/quacs/quacs/commit/560dcf06f2522b917e86e0f897297b55c74f52d7,
getSeconds() was used instead of getMinutes().