### PR TITLE
scrapers: remove hack for fall 2021

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -59,11 +59,6 @@ jobs:
           repository: quacs/quacs-data
           path: quacs-data
 
-      - name: Add Fall 2021 schools
-        run: |
-          mkdir scrapers/data/202109
-          cp quacs-data/semester_data/202109/schools.json scrapers/data/202109
-
       - name: Upload data
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
The Fall 2021 schools are now officially available which is causing this
step to fail.

Resolves following CI failures:
1. https://github.com/quacs/quacs/runs/3623016096
2. https://github.com/quacs/quacs/runs/3622336466
3. https://github.com/quacs/quacs/runs/3621755424
4. https://github.com/quacs/quacs/runs/3621242458