### PR TITLE
Add python black to CI and disable datadog

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,16 +18,29 @@ jobs:
       - name: Update submodules
         run: git submodule update --remote --recursive
 
-      - name: Clean install dependencies
+      - name: Clean install JS dependencies
         working-directory: ./site
         run: yarn install --frozen-lockfile
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-      - name: Run linter
+      - name: Run JS linter
         working-directory: ./site
         run: yarn lint --no-fix --max-warnings 0
+
+      - name: Set up python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Install pip requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scrapers/requirements.txt
+
+      - name: Run Python linter
+        run: black . --check
 
       - name: Rust tests
         working-directory: ./site

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -394,38 +394,38 @@ jobs:
               https://api.github.com/repos/quacs/quacs/dispatches
 
 
-  datadog-metrics:
-    name: Send Datadog metrics
-    runs-on: ubuntu-latest
-    needs:
-      - commit-data
-    steps:
-      - name: Install Datadog agent
-        run: |
-          DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=${{ secrets.DATADOG_API_KEY }} DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
+  # datadog-metrics:
+  #   name: Send Datadog metrics
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - commit-data
+  #   steps:
+  #     - name: Install Datadog agent
+  #       run: |
+  #         DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=${{ secrets.DATADOG_API_KEY }} DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 
-      - name: Checkout branch
-        uses: actions/checkout@v2
+  #     - name: Checkout branch
+  #       uses: actions/checkout@v2
 
-      - name: Set up python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
+  #     - name: Set up python
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: "3.x"
 
-      - name: Install pip requirements
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r scrapers/requirements.txt
+  #     - name: Install pip requirements
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install -r scrapers/requirements.txt
 
-      - name: Checkout data repository
-        uses: actions/checkout@v2
-        with:
-          path: "scrapers/data"
-          repository: "quacs/quacs-data"
-          ref: "master"
-          clean: true
-          token: ${{ secrets.GITHUBTOKEN }}
+  #     - name: Checkout data repository
+  #       uses: actions/checkout@v2
+  #       with:
+  #         path: "scrapers/data"
+  #         repository: "quacs/quacs-data"
+  #         ref: "master"
+  #         clean: true
+  #         token: ${{ secrets.GITHUBTOKEN }}
 
-      - name: Generate and send metrics
-        working-directory: ./scrapers
-        run: python3 datadog/send_metrics.py
+  #     - name: Generate and send metrics
+  #       working-directory: ./scrapers
+  #       run: python3 datadog/send_metrics.py

--- a/scrapers/datadog/send_metrics.py
+++ b/scrapers/datadog/send_metrics.py
@@ -5,18 +5,17 @@ import json
 
 NUMBER_OF_TERMS = 3
 
-options = {
-    'statsd_host':'127.0.0.1',
-    'statsd_port':8125
-}
+options = {"statsd_host": "127.0.0.1", "statsd_port": 8125}
 
 initialize(**options)
 
-def get_tag_list(tags:Dict[str,str]) -> List[str]:
+
+def get_tag_list(tags: Dict[str, str]) -> List[str]:
     tag_list = []
-    for key,value in tags.items():
+    for key, value in tags.items():
         tag_list.append(f"{key}:{value}")
     return tag_list
+
 
 # Gets the newest NUMBER_OF_TERMS terms
 def get_terms() -> List[str]:
@@ -26,26 +25,44 @@ def get_terms() -> List[str]:
 
 
 tags = {}
-if(os.environ.get("GITHUB_ACTIONS")):
-    tags['env'] = "github"
+if os.environ.get("GITHUB_ACTIONS"):
+    tags["env"] = "github"
 else:
-    tags['env'] = "dev"
+    tags["env"] = "dev"
 
 for term in get_terms():
     with open(f"data/semester_data/{term}/courses.json") as json_file:
-            courses = json.load(json_file)
-            tags['term']=term
-            for department in courses:
-                tags['department']=department["code"]
-                for course in department["courses"]:
-                    tags['course']=course["crse"]
-                    for section in course["sections"]:
-                        tags['title']=section["title"]
-                        tags['crn']=section["crn"]
-                        tags['section_number']=section["sec"]
-                        tags['credits_min']=section['credMin']
-                        tags['credits_max']=section['credMax']
-                        print(get_tag_list(tags), "Actual:", section['act'], "Remaining:", section['rem'], "Capacity:", section['cap'])
-                        statsd.gauge('quacs.section.actual', section['act'], tags=get_tag_list(tags))
-                        statsd.gauge('quacs.section.remaining', section['rem'], tags=get_tag_list(tags))
-                        statsd.gauge('quacs.section.capacity', section['cap'], tags=get_tag_list(tags))
+        courses = json.load(json_file)
+        tags["term"] = term
+        for department in courses:
+            tags["department"] = department["code"]
+            for course in department["courses"]:
+                tags["course"] = course["crse"]
+                for section in course["sections"]:
+                    tags["title"] = section["title"]
+                    tags["crn"] = section["crn"]
+                    tags["section_number"] = section["sec"]
+                    tags["credits_min"] = section["credMin"]
+                    tags["credits_max"] = section["credMax"]
+                    print(
+                        get_tag_list(tags),
+                        "Actual:",
+                        section["act"],
+                        "Remaining:",
+                        section["rem"],
+                        "Capacity:",
+                        section["cap"],
+                    )
+                    statsd.gauge(
+                        "quacs.section.actual", section["act"], tags=get_tag_list(tags)
+                    )
+                    statsd.gauge(
+                        "quacs.section.remaining",
+                        section["rem"],
+                        tags=get_tag_list(tags),
+                    )
+                    statsd.gauge(
+                        "quacs.section.capacity",
+                        section["cap"],
+                        tags=get_tag_list(tags),
+                    )

--- a/scrapers/requirements.txt
+++ b/scrapers/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv==0.19.0
 requests==2.26.0
 tqdm==4.62.2
 datadog==0.42.0
+black==21.8b0

--- a/scrapers/rmp_scraper/main.py
+++ b/scrapers/rmp_scraper/main.py
@@ -26,28 +26,37 @@ import requests
 import json
 import math
 
-def createprofessorlist():#creates List object that include basic information on all Professors from the IDed University
+
+def createprofessorlist():  # creates List object that include basic information on all Professors from the IDed University
     tempprofessorlist = []
     num_of_prof = GetNumOfProfessors(UniversityId)
     num_of_pages = math.ceil(num_of_prof / 20)
     i = 1
-    while (i <= num_of_pages):# the loop insert all professor into list
-        page = requests.get("http://www.ratemyprofessors.com/filter/professor/?&page=" + str(
-            i) + "&filter=teacherlastname_sort_s+asc&query=*%3A*&queryoption=TEACHER&queryBy=schoolId&sid=" + str(
-            UniversityId))
+    while i <= num_of_pages:  # the loop insert all professor into list
+        page = requests.get(
+            "http://www.ratemyprofessors.com/filter/professor/?&page="
+            + str(i)
+            + "&filter=teacherlastname_sort_s+asc&query=*%3A*&queryoption=TEACHER&queryBy=schoolId&sid="
+            + str(UniversityId)
+        )
         temp_jsonpage = json.loads(page.content)
-        temp_list = temp_jsonpage['professors']
+        temp_list = temp_jsonpage["professors"]
         tempprofessorlist.extend(temp_list)
         i += 1
     return tempprofessorlist
 
-def GetNumOfProfessors(id):  # function returns the number of professors in the university of the given ID.
+
+def GetNumOfProfessors(
+    id,
+):  # function returns the number of professors in the university of the given ID.
     page = requests.get(
-        "http://www.ratemyprofessors.com/filter/professor/?&page=1&filter=teacherlastname_sort_s+asc&query=*%3A*&queryoption=TEACHER&queryBy=schoolId&sid=" + str(
-            id))  # get request for page
+        "http://www.ratemyprofessors.com/filter/professor/?&page=1&filter=teacherlastname_sort_s+asc&query=*%3A*&queryoption=TEACHER&queryBy=schoolId&sid="
+        + str(id)
+    )  # get request for page
     temp_jsonpage = json.loads(page.content)
-    num_of_prof = temp_jsonpage[
-                      'remaining'] + 20  # get the number of professors at William Paterson University
+    num_of_prof = (
+        temp_jsonpage["remaining"] + 20
+    )  # get the number of professors at William Paterson University
     return num_of_prof
 
 
@@ -56,4 +65,4 @@ rpiProfessorlist = createprofessorlist()
 
 print(json.dumps(rpiProfessorlist, indent=4, sort_keys=True))
 with open(f"rmp.json", "w") as outfile:  # -{os.getenv("CURRENT_TERM")}
-    json.dump(rpiProfessorlist , outfile, sort_keys=False, indent=2)
+    json.dump(rpiProfessorlist, outfile, sort_keys=False, indent=2)


### PR DESCRIPTION
This adds python black to the ci because I realized we did not have a python linter
I also disable the datadog stuff for now. We can maybe at some point work on updating that code to fit within the datadog limits or use it to write our own metrics to the quacs-data repo
