### PR TITLE
Rewrite catalog scraper to work with API

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -3,9 +3,9 @@ on:
   repository_dispatch:
     types: scrape
   # TODO Ideally this will only run when changes to the scraper folder are made
-  push:
-    branches:
-      - master
+  # push:
+  #   branches:
+  #     - master
   schedule:
     - cron: '0 * * * *'
   workflow_dispatch:

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -261,13 +261,14 @@ jobs:
           pip install -r scrapers/requirements.txt
 
       - name: Scrape catalog
+        working-directory: ./scrapers
         run: python3 catalog_scraper/main.py
 
       - name: Upload data
         uses: actions/upload-artifact@v2
         with:
           name: catalog
-          path: data/
+          path: scrapers/data
 
   commit-data:
     name: Commit changes

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -6,8 +6,8 @@ on:
   # push:
   #   branches:
   #     - master
-  schedule:
-    - cron: '0 * * * *'
+  # schedule:
+  #   - cron: '0 * * * *'
   workflow_dispatch:
     inputs:
       scrape_all:
@@ -299,7 +299,7 @@ jobs:
         run: |
           for directory in $(find courses/* -type d -print0 | xargs -0); do
             DIR_BASENAME=$(basename "$directory")
-            cp -r catalog/$DIR_BASENAME/* "$directory"
+            cp -r catalog/$DIR_BASENAME/* "$directory" | true
           done
 
           rsync -avz courses/ data/semester_data/

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -297,7 +297,7 @@ jobs:
       - name: Commit new data
         working-directory: ./scrapers
         run: |
-          for directory in $(find courses/* -type d -print0 | xargs -0); do
+          for directory in $(find courses/* -type d -maxdepth 0 -print0 | xargs -0); do
             DIR_BASENAME=$(basename "$directory")
             cp -r catalog/$DIR_BASENAME/* "$directory" | true
           done
@@ -313,7 +313,7 @@ jobs:
           rsync -avzh --ignore-missing-args transfer/transfer.json data || true
 
           rsync -avzh --ignore-missing-args transfer_guides/ data/transfer_guides/ || true
-          tree
+
           cd data
 
           # Merge any hard_coded data into the final values

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -11,9 +11,9 @@ on:
   workflow_dispatch:
     inputs:
       scrape_all:
-        description: 'Scrape all semesters (all|current)'
+        description: 'Scrape all semesters (ALL_YEARS|CURRENT_YEAR)'
         required: true
-        default: 'current'
+        default: 'CURRENT_YEAR'
 
 jobs:
   scrape-courses-and-prerequisites:
@@ -313,7 +313,7 @@ jobs:
           rsync -avzh --ignore-missing-args transfer/transfer.json data || true
 
           rsync -avzh --ignore-missing-args transfer_guides/ data/transfer_guides/ || true
-
+          tree
           cd data
 
           # Merge any hard_coded data into the final values
@@ -343,12 +343,14 @@ jobs:
           git commit -m "$(date -u)" # || exit 0
           #git add meta.json
           #git commit --amend --no-edit
-          git push --force
-          curl -H "Accept: application/vnd.github.everest-preview+json" \
-              -H "Authorization: token ${{ secrets.GITHUBTOKEN }}" \
-              --request POST \
-              --data '{"event_type": "deploy", "client_payload": {"build_args": "-d"}}' \
-              https://api.github.com/repos/quacs/quacs/dispatches
+
+          # TODO add this back in
+          # git push --force
+          # curl -H "Accept: application/vnd.github.everest-preview+json" \
+          #     -H "Authorization: token ${{ secrets.GITHUBTOKEN }}" \
+          #     --request POST \
+          #     --data '{"event_type": "deploy", "client_payload": {"build_args": "-d"}}' \
+          #     https://api.github.com/repos/quacs/quacs/dispatches
 
 
   # datadog-metrics:

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -299,7 +299,7 @@ jobs:
         run: |
           for directory in $(find courses/* -type d -maxdepth 0 -print0 | xargs -0); do
             DIR_BASENAME=$(basename "$directory")
-            cp -r catalog/$DIR_BASENAME/* "$directory" | true
+            rsync -avzh --ignore-missing-args catalog/$DIR_BASENAME/* "$directory" || true
           done
 
           rsync -avz courses/ data/semester_data/

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -41,9 +41,7 @@ jobs:
 
       - name: Copy all_schools.json to correct location
         working-directory: ./scrapers/quacs-data
-        run: cp all_schools.json ../catalog_scraper/all_schools.json
-
-
+        run: cp all_schools.json ../all_schools.json
 
       - name: Scrape courses
         working-directory: ./scrapers

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -3,11 +3,11 @@ on:
   repository_dispatch:
     types: scrape
   # TODO Ideally this will only run when changes to the scraper folder are made
-  # push:
-  #   branches:
-  #     - master
-  # schedule:
-  #   - cron: '0 * * * *'
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '0 * * * *'
   workflow_dispatch:
     inputs:
       scrape_all:
@@ -262,7 +262,7 @@ jobs:
 
       - name: Scrape catalog
         working-directory: ./scrapers
-        run: python3 catalog_scraper/main.py
+        run: python3 catalog_scraper/main.py ${{ github.event.inputs.scrape_all }}
 
       - name: Upload data
         uses: actions/upload-artifact@v2
@@ -344,13 +344,12 @@ jobs:
           #git add meta.json
           #git commit --amend --no-edit
 
-          # TODO add this back in
-          # git push --force
-          # curl -H "Accept: application/vnd.github.everest-preview+json" \
-          #     -H "Authorization: token ${{ secrets.GITHUBTOKEN }}" \
-          #     --request POST \
-          #     --data '{"event_type": "deploy", "client_payload": {"build_args": "-d"}}' \
-          #     https://api.github.com/repos/quacs/quacs/dispatches
+          git push --force
+          curl -H "Accept: application/vnd.github.everest-preview+json" \
+              -H "Authorization: token ${{ secrets.GITHUBTOKEN }}" \
+              --request POST \
+              --data '{"event_type": "deploy", "client_payload": {"build_args": "-d"}}' \
+              https://api.github.com/repos/quacs/quacs/dispatches
 
 
   # datadog-metrics:

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -247,10 +247,8 @@ jobs:
     name: Scrapes catalog by year
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout scrapers
+      - name: Checkout branch
         uses: actions/checkout@v2
-        with:
-          ref: 'master'
 
       - name: Set up python
         uses: actions/setup-python@v2
@@ -260,7 +258,7 @@ jobs:
       - name: Install pip requirements
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r scrapers/requirements.txt
 
       - name: Scrape catalog
         run: python3 catalog_scraper/main.py

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -9,20 +9,17 @@ on:
   schedule:
     - cron: '0 * * * *'
   workflow_dispatch:
+    inputs:
+      scrape_all:
+        description: 'Scrape all semesters (all|current)'
+        required: true
+        default: 'current'
 
 jobs:
-  scrape-schools:
-    name: Scrapes schools per year
+  scrape-courses-and-prerequisites:
+    name: Scrapes courses and prerequisites
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
-      - name: Print event name
-        run: echo $GITHUB_EVENT_NAME
-
       - name: Checkout branch
         uses: actions/checkout@v2
 
@@ -35,64 +32,22 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r scrapers/requirements.txt
-
-      - name: Scrape schools
-        working-directory: ./scrapers
-        run: python3 catalog_scraper/main.py schools LATEST_YEAR
-
-      - name: Output semesters
-        working-directory: ./scrapers
-        run: |
-          echo -n "::set-output name=semesters::["
-          ITER=0
-          for directory in $(find data -print0 | xargs -0); do
-            if test $ITER -ne 0; then
-              echo -n ","
-            fi
-            echo -n "\"$directory\""
-            ITER=$((ITER + 1))
-          done
-          echo "]"
 
       - name: Clone QuACS Data
         uses: actions/checkout@v2
         with:
           repository: quacs/quacs-data
-          path: quacs-data
+          path: scrapers/quacs-data
 
-      - name: Upload data
-        uses: actions/upload-artifact@v2
-        with:
-          name: schools
-          path: scrapers/data/
+      - name: Copy all_schools.json to correct location
+        working-directory: ./scrapers/quacs-data
+        run: cp all_schools.json ../catalog_scraper/all_schools.json
 
-  scrape-courses-and-prerequisites:
-    name: Scrapes courses and prerequisites
-    runs-on: ubuntu-latest
-    needs: [scrape-schools]
-    steps:
-      - name: Checkout branch
-        uses: actions/checkout@v2
 
-      - name: Set up python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-
-      - name: Install pip requirements
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r scrapers/requirements.txt
-
-      - name: Get semester data
-        uses: actions/download-artifact@v2
-        with:
-          name: schools
-          path: scrapers/data
 
       - name: Scrape courses
         working-directory: ./scrapers
-        run: python3 sis_scraper/main.py
+        run: python3 sis_scraper/main.py ${{ github.event.inputs.scrape_all }}
 
       - name: Upload semester-specific data
         uses: actions/upload-artifact@v2
@@ -288,33 +243,33 @@ jobs:
           path: scrapers/transfer_guides
 
   # This may need to be updated now that the scrapers have been moved into the same repo as the site
-  # scrape-catalog:
-  #   name: Scrapes catalog by year
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout scrapers
-  #       uses: actions/checkout@v2
-  #       with:
-  #         ref: 'master'
+  scrape-catalog:
+    name: Scrapes catalog by year
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout scrapers
+        uses: actions/checkout@v2
+        with:
+          ref: 'master'
 
-  #     - name: Set up python
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: '3.x'
+      - name: Set up python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
 
-  #     - name: Install pip requirements
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install -r requirements.txt
+      - name: Install pip requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
-  #     - name: Scrape catalog
-  #       run: python3 catalog_scraper/main.py catalog LATEST_YEAR
+      - name: Scrape catalog
+        run: python3 catalog_scraper/main.py
 
-  #     - name: Upload data
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: catalog
-  #         path: data/
+      - name: Upload data
+        uses: actions/upload-artifact@v2
+        with:
+          name: catalog
+          path: data/
 
   commit-data:
     name: Commit changes
@@ -324,6 +279,7 @@ jobs:
       - scrape-faculty
       # - scrape-hass-pathways
       - scrape-prereq-graph
+      - scrape-catalog
     steps:
       - name: Checkout data repository
         uses: actions/checkout@v2
@@ -342,10 +298,10 @@ jobs:
       - name: Commit new data
         working-directory: ./scrapers
         run: |
-          # for directory in $(find courses/* -type d -print0 | xargs -0); do
-          #   DIR_BASENAME=$(basename "$directory")
-          #   cp -r catalog/$DIR_BASENAME/* "$directory"
-          # done
+          for directory in $(find courses/* -type d -print0 | xargs -0); do
+            DIR_BASENAME=$(basename "$directory")
+            cp -r catalog/$DIR_BASENAME/* "$directory"
+          done
 
           rsync -avz courses/ data/semester_data/
 

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -39,9 +39,11 @@ jobs:
           repository: quacs/quacs-data
           path: scrapers/quacs-data
 
-      - name: Copy all_schools.json to correct location
+      - name: Copy quacs-data files to correct locations
         working-directory: ./scrapers/quacs-data
-        run: cp all_schools.json ../all_schools.json
+        run: |
+          cp all_schools.json ../all_schools.json
+          cp semester_data ../data -r
 
       - name: Scrape courses
         working-directory: ./scrapers

--- a/scrapers/catalog_scraper/main.py
+++ b/scrapers/catalog_scraper/main.py
@@ -109,6 +109,10 @@ def save_catalog(data: Dict, year: str):
 
 
 if __name__ == "__main__":
+    if sys.argv[-1] == "help" or sys.argv[-1] == "--help":
+        print(f"USAGE: python3 {sys.argv[0]} [ALL_YEARS]")
+        sys.exit(1)
+
     catalogs = get_catalogs()
 
     if sys.argv[-1] != "ALL_YEARS":

--- a/scrapers/catalog_scraper/main.py
+++ b/scrapers/catalog_scraper/main.py
@@ -113,14 +113,16 @@ def save_catalog(data, year):
 
 if __name__ == "__main__":
     if sys.argv[-1] == "help":
-        print(f"USAGE: python3 {sys.argv[0]} [LATEST_YEAR]")
+        print(f"USAGE: python3 {sys.argv[0]} [ALL_YEARS]")
         sys.exit(1)
 
     catalogs = get_catalogs()
 
-    if sys.argv[-1] == "LATEST_YEAR":
+    if sys.argv[-1] != "ALL_YEARS":
         print("Parsing single year")
         catalogs = catalogs[:1]
+    else:
+        print("Parsing all years")
 
     for index, (year, catalog_id) in enumerate(tqdm(catalogs)):
         course_ids = get_course_ids(catalog_id)

--- a/scrapers/catalog_scraper/main.py
+++ b/scrapers/catalog_scraper/main.py
@@ -107,13 +107,13 @@ def save_catalog(data, year):
     for directory in (f"{years[0]}09", f"{years[1]}01", f"{years[1]}05"):
         directory = "data/" + directory
         os.makedirs(directory, exist_ok=True)
-        with open(f"{directory}/{sys.argv[1]}.json", "w") as outfile:
+        with open(f"{directory}/catalog.json", "w") as outfile:
             json.dump(data, outfile, sort_keys=True, indent=2, ensure_ascii=False)
 
 
 if __name__ == "__main__":
     if len(sys.argv) == 1:
-        print(f"USAGE: python3 {sys.argv[0]} (catalog|schools)")
+        print(f"USAGE: python3 {sys.argv[0]} [LATEST_YEAR]")
         sys.exit(1)
 
     catalogs = get_catalogs()

--- a/scrapers/catalog_scraper/main.py
+++ b/scrapers/catalog_scraper/main.py
@@ -1,246 +1,126 @@
-import os
 import requests
-from bs4 import BeautifulSoup
-import json
-import re
 import sys
+from lxml import html
+import os
 from tqdm import tqdm
-import time
-from shutil import copyfile
+import json
+from lxml import etree
 
-from typing import Tuple, List
+# The api key is public so it does not need to be hidden in a .env file
+BASE_URL = "http://rpi.apis.acalog.com/v1/"
+DEFAULT_QUERY_PARAMS = "?key=3eef8a28f26fb2bcc514e6f1938929a1f9317628&format=xml"
+CHUNK_SIZE = 500
 
-import asyncio
-import aiohttp
-
-BASE_URL = "http://catalog.rpi.edu"
-HEADERS = {
-    "Content-Type": "application/x-www-form-urlencoded",
-}
-
-# returns [(year, courses url, schools url)]
-async def get_years() -> List[Tuple[str, str, str]]:
-    async with aiohttp.ClientSession() as s:
-        async with s.get(f"{BASE_URL}/index.php") as homepage:
-            homepage_text = await homepage.text()
-            home_soup = BeautifulSoup(homepage_text.encode("utf8"), "lxml")
-            dropdown_entries = home_soup.find(
-                "select", {"name": "catalog"}
-            ).findChildren("option", recursive=False)
-
-            dropdown_mapped = map(lambda x: (x["value"], x.string), dropdown_entries)
-            dropdown_formatted = map(
-                lambda x: (x[0], x[1].split(" [")[0]), dropdown_mapped
-            )
-            dropdown_formatted = map(
-                lambda x: (x[0], x[1].split("Catalog ")[1]), dropdown_formatted
-            )
-
-            ret = []
-
-            for val, year in dropdown_formatted:
-                async with s.post(
-                    f"{BASE_URL}/index.php",
-                    headers=HEADERS,
-                    data={"catalog": val, "sel_cat_submit": "GO"},
-                ) as year_home:
-                    year_home_text = await year_home.text()
-                    year_home_soup = BeautifulSoup(
-                        year_home_text.encode("utf8"), "lxml"
-                    )
-                    courses_url = year_home_soup("a", text="Courses")[0]["href"]
-                    schools_url = year_home_soup("a", text="Subject Codes")[0]["href"]
-                    ret.append((year, BASE_URL + courses_url, BASE_URL + schools_url))
-
-            return ret
+# returns the list of catalogs with the newest one being first
+# each catalog is a tuple (year, catalog_id) ex: ('2020-2021', 21)
 
 
-async def scrape_course_data(s, url, data):
-    # Try scraping this page up to 10 times
-    for i in range(10):
-        async with s.get(url) as course_results:
-            data_soup = BeautifulSoup(await course_results.text("utf8"), "lxml")
-            course = data_soup.find("h1").contents[0].split("-")
-            if course[0] == "503 Service Temporarily Unavailable":
-                print(f"attempt {i} failed to scrape {url}, trying again...")
-                continue
-            course_code = course[0].split()
-            key = course_code[0].strip() + "-" + course_code[1].strip()
-            data[key] = {}
-            data[key]["subj"] = course_code[0].strip()
-            data[key]["crse"] = course_code[1].strip()
-            data[key]["name"] = course[1].strip()
-            # data[key]['url'] = url
-            # data[key]['coid'] = url.split('=')[-1]
+def get_catalogs():
+    catalogs_xml = html.fromstring(
+        requests.get(
+            f"{BASE_URL}content{DEFAULT_QUERY_PARAMS}&method=getCatalogs"
+        ).text.encode("utf8")
+    )
+    catalogs = catalogs_xml.xpath("//catalogs/catalog")
 
-            description = data_soup.find("hr")
-            if description:
-                description = description.parent.encode_contents().decode().strip()
-                description = re.split("<\/?hr ?\/?>", description)[1]
-                description = re.split("<\/?br ?\/?>\s*<strong>", description)[0]
-                description = re.sub("<.*?>", "", description)
-                data[key]["description"] = description.strip()
+    ret = []
+    # For each catalog get its year and id and add that as as tuples to ret
+    for catalog in catalogs:
+        catalog_id = catalog.xpath("@id")[0].split("acalog-catalog-")[1]
+        catalog_year = catalog.xpath(".//title/text()")[0].split("Rensselaer Catalog ")[
+            1
+        ]
+        ret.append((catalog_year, catalog_id))
 
-            # when_offered = data_soup.find('strong', text='When Offered:')
-            # if when_offered:
-            #     data[key]['when_offered'] = when_offered.nextSibling.strip()
-            #
-            # cross_listed = data_soup.find('strong', text='Cross Listed:')
-            # if cross_listed:
-            #     data[key]['cross_listed'] = cross_listed.nextSibling.strip()
-            #
-            # pre_req = data_soup.find('strong', text='Prerequisites/Corequisites:')
-            # if pre_req:
-            #     data[key]['pre_req'] = pre_req.nextSibling.strip()
-            #
-            # credit_hours = data_soup.find('em', text='Credit Hours:')
-            # if credit_hours:
-            #     credit_hours = credit_hours.nextSibling.nextSibling.text.strip()
-            #     if(credit_hours == 'Variable'):
-            #         data[key]['credit_hours_max'] = 0
-            #         data[key]['credit_hours_min'] = 999
-            #     else:
-            #         data[key]['credit_hours'] = credit_hours
-
-            # If we got here the code must have worked which means we dont need to try again and therefore we can return
-            return
-    raise Exception(f"Failed to scrape {url}")
+    # sort so that the newest catalog is always first
+    ret.sort(key=lambda tup: tup[0], reverse=True)
+    return ret
 
 
-# TODO: add proper rate limiting
-async def scrape_catalog(s, courses_url, data):
-    print(courses_url)
-
-    # Go to the list of pages that contain courses, find the urls to every course, add them to the urls array
-    urls = []
-    index = 1
-    while True:
-        url = f"{courses_url}&filter%5Bitem_type%5D=3&filter%5Bonly_active%5D=1&filter%5B3%5D=1&filter%5Bcpage%5D={index}#acalog_template_course_filter"
-        # response = requests.get(url)
-        async with s.get(url) as response:
-            soup = BeautifulSoup(await response.text("utf8"), "lxml")
-
-            rows = soup.find_all(
-                "a",
-                {
-                    "href": re.compile(
-                        r"preview_course_nopop.php\?catoid=\d+?&coid=\d+?"
-                    )
-                },
-            )
-
-            # This page is empty, the last page must have been the last page that contained courses
-            if len(rows) == 0:
-                break
-
-            for row in rows:
-                await scrape_course_data(
-                    s,
-                    f"http://catalog.rpi.edu/preview_course.php?{row['href'].split('?')[1]}&print",
-                    data,
-                )
-                urls.append(
-                    f"http://catalog.rpi.edu/preview_course.php?{row['href'].split('?')[1]}&print"
-                )
-
-        index += 1
-
-    # await asyncio.gather(*(scrape_course_data(s, url, data) for url in urls))
+# Returns a list of course ids for a given catalog
+def get_course_ids(catalog_id):
+    courses_xml = html.fromstring(
+        requests.get(
+            f"{BASE_URL}search/courses{DEFAULT_QUERY_PARAMS}&method=listing&options[limit]=0&catalog={catalog_id}"
+        ).text.encode("utf8")
+    )
+    return courses_xml.xpath("//id/text()")
 
 
-async def get_schools(s, url):
-    async with s.get(url) as homepage:
-        soup = BeautifulSoup(await homepage.text("utf8"), "lxml")
-        schools = soup.find("h3", text="Four-Letter Subject Codes by School")
-        num_schools = len(
-            list(
-                filter(lambda x: str(x).strip(), schools.next_siblings),
-            )
-        )
-
-        school = schools
-        data = {}
-        departments = set()
-        for _ in range(num_schools):
-            school = school.findNext("p")
-
-            strings = list(school.stripped_strings)
-            school_title = strings[0]
-            school_name_end = school_title.index("(") - 1
-            school_name = school_title[:school_name_end]
-            if school_name not in data:
-                data[school_name] = []
-
-            for dept in strings[1:]:
-                first_space = dept.index(" ")
-                try:
-                    nbsp_idx = dept.index("\u00a0")
-                except ValueError:
-                    nbsp_idx = -1
-                if nbsp_idx > 0 and nbsp_idx < first_space:
-                    first_space = nbsp_idx
-                code = dept[:first_space]
-                name = dept[first_space + 1 :]
-                if code not in departments:
-                    data[school_name].append({"code": code, "name": name})
-                departments.add(code)
-        return data
+# Finds and returns a cleaned up description of the course
 
 
-# Gets the data for a year, this is either the school data or the catalog data
-async def get_year(year_data):
-    year, courses_url, schools_url = year_data
-    async with aiohttp.ClientSession() as s:
-        if sys.argv[1] == "catalog":
-            data = {}
-            await scrape_catalog(s, courses_url, data)
+def get_catalog_description(fields, course_name):
+    found_name = False
+    # The description is always the next full field after the course name field
+    # Itearte through the fields until we find the course name field and then return the next filled field
+    for field in fields:
+        if found_name == False:
+            name = field.xpath(".//*/text()")
+            if name and name[0] == course_name:
+                found_name = True
         else:
-            data = await get_schools(s, schools_url)
-            data = list(map(lambda x: {"name": x[0], "depts": x[1]}, data.items()))
-
-        years = year.split("-")
-        for directory in (f"{years[0]}09", f"{years[1]}01"):
-            directory = "data/" + directory
-            os.makedirs(directory, exist_ok=True)
-            with open(f"{directory}/{sys.argv[1]}.json", "w") as outfile:
-                json.dump(data, outfile, sort_keys=False, indent=2)
+            description = field.xpath(".//*/text()")
+            if description:
+                return " ".join(" ".join(description).split())
 
 
-async def get_page_urls(years_data):
-    # await asyncio.gather(*(get_year(year) for year in years_data))
-    for year in tqdm(years_data):
-        await get_year(year)
+def get_course_data(course_ids):
+    data = {}
+    # Break the courses into chunks of CHUNK_SIZE to make the api happy
+    course_chunks = [
+        course_ids[i : i + CHUNK_SIZE] for i in range(0, len(course_ids), CHUNK_SIZE)
+    ]
+    for chunk in course_chunks:
+        ids = "".join([f"&ids[]={id}" for id in chunk])
+        url = f"{BASE_URL}content{DEFAULT_QUERY_PARAMS}&method=getItems&options[full]=1&catalog={catalog_id}&type=courses{ids}"
+
+        courses_xml = html.fromstring(requests.get(url).text.encode("utf8"))
+        courses = courses_xml.xpath("//courses/course[not(@child-of)]")
+        for course in courses:
+            subj = course.xpath("./content/prefix/text()")[0].strip()
+            crse = course.xpath("./content/code/text()")[0].strip()
+            course_name = course.xpath("./content/name/text()")[0].strip()
+            fields = course.xpath("./content/field")
+
+            data[f"{subj}-{crse}"] = {
+                "subj": subj,
+                "crse": crse,
+                "name": course.xpath("./content/name/text()")[0].strip(),
+                "description": get_catalog_description(fields, course_name),
+                "raw_xml": etree.tostring(course).decode("utf8")  # used for debugging
+            }
+
+    return data
 
 
-years = asyncio.run(get_years())
+# Saves the catalog to the 3 semesters for that year
+def save_catalog(data, year):
+    years = year.split("-")
+    for directory in (f"{years[0]}09", f"{years[1]}01", f"{years[1]}05"):
+        directory = "data/" + directory
+        os.makedirs(directory, exist_ok=True)
+        with open(f"{directory}/{sys.argv[1]}.json", "w") as outfile:
+            json.dump(data, outfile, sort_keys=True, indent=2, ensure_ascii=False)
 
-if len(sys.argv) == 1:
-    print(f"USAGE: python3 {sys.argv[0]} (catalog|schools)")
-    sys.exit(1)
 
-if sys.argv[-1] == "LATEST_YEAR":
-    print("Parsing single year")
-    asyncio.run(get_page_urls(years[:1]))
-else:
-    asyncio.run(get_page_urls(years))
+if __name__ == "__main__":
+    if len(sys.argv) == 1:
+        print(f"USAGE: python3 {sys.argv[0]} (catalog|schools)")
+        sys.exit(1)
 
-"""
-# Duplicate the final summer semester to fall of the next year. This is for if
-# the catalog does not update fast enough for the fall semester
-os.makedirs(f"data/{years[0][0].split('-')[1]}09", exist_ok=True)
-try:
-    copyfile(
-        f"data/{years[0][0].split('-')[1]}05/schools.json",
-        f"data/{years[0][0].split('-')[1]}09/schools.json",
-    )
-except:
-    print("schools.json does not exist for the final semester")
+    catalogs = get_catalogs()
 
-try:
-    copyfile(
-        f"data/{years[0][0].split('-')[1]}05/catalog.json",
-        f"data/{years[0][0].split('-')[1]}09/catalog.json",
-    )
-except:
-    print("catalog.json does not exist for the final semester")
-"""
+    if sys.argv[-1] == "LATEST_YEAR":
+        print("Parsing single year")
+        catalogs = catalogs[:1]
+
+    for index, (year, catalog_id) in enumerate(tqdm(catalogs)):
+        course_ids = get_course_ids(catalog_id)
+        data = get_course_data(course_ids)
+        save_catalog(data, year)
+
+        # Save the final catalog for the next year to account for delays in uploading the catalog
+        if index == len(catalogs) - 1:
+            years = year.split("-")
+            save_catalog(data, f"{int(years[0])+1}-{int(years[1])+1}")

--- a/scrapers/catalog_scraper/main.py
+++ b/scrapers/catalog_scraper/main.py
@@ -112,7 +112,7 @@ def save_catalog(data, year):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) == 1:
+    if sys.argv[-1] == "help":
         print(f"USAGE: python3 {sys.argv[0]} [LATEST_YEAR]")
         sys.exit(1)
 

--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -298,6 +298,8 @@ async def scrape_term(term):
     for school in schools:
         school["depts"] = sorted(school["depts"], key=itemgetter("code"))
 
+    os.makedirs(f"data/{term}", exist_ok=True)
+
     school_columns = util.optimize_column_ordering(schools)
     # Write out all the results of the scraper
     conflict_logic.gen(term, courses)

--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -332,6 +332,10 @@ async def scrape_term(term):
 
 
 async def main():
+    if sys.argv[-1] == "help" or sys.argv[-1] == "--help":
+        print(f"USAGE: python3 {sys.argv[0]} [ALL_YEARS]")
+        sys.exit(1)
+
     global session
     async with aiohttp.ClientSession(
         connector=aiohttp.TCPConnector(limit=5)

--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -6,6 +6,7 @@ from operator import itemgetter
 import os
 import re
 import json
+import sys
 
 # External dependnecies
 import aiohttp
@@ -252,14 +253,9 @@ async def scrape_term(term):
 
     # Ensure data/{term} exists
     os.makedirs(f"data/{term}", exist_ok=True)
-    try:
-        with open(f"data/{term}/schools.json", "r") as all_schools_f:
-            all_schools = json.load(all_schools_f)
-    except:
-        print(
-            f"Failed to load data/{term}/schools.json. Generating an empty one -- all courses will be uncategorized!"
-        )
-        all_schools = []
+
+    with open(f"all_schools.json", "r") as all_schools_f:
+        all_schools = json.load(all_schools_f)
 
     # Ensure schools.json is populated properly
     matched_subjects = set()
@@ -338,7 +334,14 @@ async def main():
     async with aiohttp.ClientSession(
         connector=aiohttp.TCPConnector(limit=5)
     ) as session:
-        for semester in util.get_semesters_to_scrape():
+        semesters = util.get_semesters_to_scrape()
+
+        if(sys.argv[-1] == "all"):
+            for term in os.listdir("data/"):
+                if(term not in semesters):
+                    semesters.append(term)
+
+        for semester in semesters:
             await scrape_term(semester)
 
 

--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -298,8 +298,6 @@ async def scrape_term(term):
     for school in schools:
         school["depts"] = sorted(school["depts"], key=itemgetter("code"))
 
-    os.makedirs(f"data/{term}", exist_ok=True)
-
     school_columns = util.optimize_column_ordering(schools)
     # Write out all the results of the scraper
     conflict_logic.gen(term, courses)

--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -338,10 +338,13 @@ async def main():
     ) as session:
         semesters = util.get_semesters_to_scrape()
 
-        if sys.argv[-1] == "all":
+        if sys.argv[-1] == "ALL_YEARS":
+            print("Parsing all years")
             for term in os.listdir("data/"):
                 if term not in semesters:
                     semesters.append(term)
+        else:
+            print("Parsing relevant terms only")
 
         for semester in semesters:
             await scrape_term(semester)

--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -336,9 +336,9 @@ async def main():
     ) as session:
         semesters = util.get_semesters_to_scrape()
 
-        if(sys.argv[-1] == "all"):
+        if sys.argv[-1] == "all":
             for term in os.listdir("data/"):
-                if(term not in semesters):
+                if term not in semesters:
                     semesters.append(term)
 
         for semester in semesters:


### PR DESCRIPTION
This rewrites the entire catalog to use the catalog API

It is much faster and does not cause the catalog to crash therefore we can add it back into the scraper. (which I still need to do and why this PR is WIP)

I also made it so that it generates the catalog for the next year using the current catalog. This will help when we transition between semesters but the catalog has not gotten a new version which has happened before.