### PR TITLE
sis-scraper: fix text normalization

### DIFF
--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -2,6 +2,7 @@
 
 # Python standard library
 import asyncio
+from operator import itemgetter
 import re
 import json
 
@@ -274,20 +275,21 @@ async def scrape_term(term):
     schools.append(
         {
             "name": "Uncategorized",
-            "depts": sorted(
-                (
-                    {
-                        "code": code,
-                        "name": list(
-                            filter(lambda dept: dept["code"] == code, courses)
-                        )[0]["name"],
-                    }
-                    for code in unmatched_subjects
-                ),
-                key=lambda x: x["code"],
-            ),
+            "depts": [
+                {
+                    "code": code,
+                    "name": list(filter(lambda dept: dept["code"] == code, courses))[0][
+                        "name"
+                    ],
+                }
+                for code in unmatched_subjects
+            ],
         }
     )
+
+    # Sort the departments in each school
+    for school in schools:
+        school["depts"] = sorted(school["depts"], key=itemgetter("code"))
 
     school_columns = util.optimize_column_ordering(schools)
     # Write out all the results of the scraper

--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -62,7 +62,7 @@ async def get_section_information(section_url):
         section_dict["crse"] = int(crse)
         section_dict["subj"] = subject_name
         section_dict["sec"] = section_number
-        section_dict["title"] = raw_title.title()
+        section_dict["title"] = util.normalize_class_name(raw_title)
 
         # Get seat data
         seating = soup.find(

--- a/scrapers/sis_scraper/util.py
+++ b/scrapers/sis_scraper/util.py
@@ -25,6 +25,20 @@ def get_instructor_string(input):
     )
 
 
+# COMPUTER SCIENCE II => Computer Science II
+def normalize_class_name(input):
+    text = list(input)
+
+    for i in range(1, len(text)):
+        # Capitalize the character if there is a space or a capital 'I' next to another 'I'
+        # This gives basic support for any roman numerals we encounter
+        if (text[i - 1] == " ") or (text[i - 1] == text[i] == "I"):
+            continue
+        text[i] = text[i].lower()
+
+    return "".join(text)
+
+
 def get_semesters_to_scrape():
     RPI_SEMESTER_MONTH_OFFSETS = {1, 5, 9}
     semesters = []


### PR DESCRIPTION
Python's .title() makes "MASTER'S PROJECT" turn into "Master'S Project" which is suboptimal.
Additionally, this supports basic Roman Numerals (I,II,III) to make them look nicer.