### PR TITLE
schedule: remove the 'closed' attribute, re-introduce XL logic

### DIFF
--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -81,6 +81,8 @@ async def get_section_information(section_url):
                 section_dict["cap"] = capacity
                 section_dict["act"] = actual
                 section_dict["rem"] = remaining
+            elif kind == "Cross List Seats":
+                section_dict["xl_rem"] = remaining
 
             # NOTE: Can implement logic for Waitlists / Crosslists here
     return section_dict

--- a/site/src/components/CourseCard.vue
+++ b/site/src/components/CourseCard.vue
@@ -103,15 +103,6 @@
             Hybrid Course
           </span>
         </span>
-
-        <span v-if="this.fullSections != 2 && closed">
-          <span class="padding-left prerequisiteError prerequisiteBkgError">
-            <font-awesome-icon
-              :icon="['fas', 'exclamation-triangle']"
-            ></font-awesome-icon>
-            Closed
-          </span>
-        </span>
       </div>
       <!-- <br> -->
       {{ getDescription(course.subj, course.crse) }}
@@ -172,7 +163,7 @@ Vue.use(ModalPlugin);
       let fullCount = 0;
       // @ts-expect-error: no u typescript, this does exist
       for (const section of this.course.sections) {
-        if (section.rem <= 0) {
+        if (section.rem <= 0 || section.xl_rem <= 0) {
           fullCount++;
         }
       }
@@ -236,12 +227,6 @@ export default class CourseCard extends Vue {
 
   get hybrid(): boolean {
     return this.course.sections[0].attribute.includes("Hybrid");
-  }
-
-  get closed(): boolean {
-    return this.course.sections.every(function (section) {
-      return section.closed;
-    });
   }
 
   getDescription(subject: string, code: string): string {

--- a/site/src/components/sections/SectionInfo.vue
+++ b/site/src/components/sections/SectionInfo.vue
@@ -39,8 +39,8 @@
         <div class="font-weight-bold">Visualize Prerequisites:</div>
         <PrereqGraph :course="courseCode"></PrereqGraph>
       </template>
-      <template v-if="section.closed">
-        <b>This section is currently closed.</b>
+      <template v-if="section.rem <= 0 || section.xl_rem <= 0">
+        <b>This section is currently full.</b>
         In order to register, you must submit a signed
         <a
           href="https://www.rpi.edu/dept/srfs/AuthorizationFrm.pdf"

--- a/site/src/components/sections/Sections.vue
+++ b/site/src/components/sections/Sections.vue
@@ -87,11 +87,16 @@
             ></font-awesome-icon>
             Full Section</span
           >
-
+          /* Show the XL-full message if: 1. The section is not already full
+          (avoids duplicate full section/full course) - AND - 2. The course is
+          an XL course and is out of XL seats. */
           <span
             class="padding-left prerequisiteError"
             :class="{
-              hidden: section.rem <= 0 || !section.closed,
+              hidden:
+                section.xl_rem === undefined ||
+                section.xl_rem > 0 ||
+                section.rem <= 0,
             }"
             v-on:click.stop.prevent
             v-on:keyup.enter.stop.prevent
@@ -99,10 +104,10 @@
             @keyup.enter="showSectionModal(section.crn)"
           >
             <font-awesome-icon
-              :icon="['fas', 'exclamation-triangle']"
+              :icon="['fas', 'user-slash']"
             ></font-awesome-icon>
-            Closed
-          </span>
+            Full Section (No cross-list seats remaining)</span
+          >
           <span title="Professor(s)">
             | {{ section.timeslots[0].instructor }} |
           </span>

--- a/site/src/typings.ts
+++ b/site/src/typings.ts
@@ -25,10 +25,10 @@ export interface CourseSection {
 
   cap: number;
   rem: number;
+  xl_rem: number;
 
   timeslots: Timeslot[];
   attribute: string;
-  closed: boolean;
 }
 
 export interface Course {


### PR DESCRIPTION
This change scrapes the `xl_rem` (number of total cross-listed seats
remaining for each course) and modifies the frontend to support
handling full cross-listed courses.

Cross listed courses have a total amount of seats available across
all the sections. Once this is exhausted, you cannot register even
if the section has seats left. This gives people (including myself
at times) a lot of false hope that they can actually register for a course.

A few months back, we started scraping the 'closed' attributes on SIS.
However, this no longer works with the new scraper, so we have to
mimic this functionality.