### PR TITLE
scrapers: drop python-dotenv dependency

### DIFF
--- a/scrapers/requirements.txt
+++ b/scrapers/requirements.txt
@@ -1,7 +1,6 @@
 aiohttp==3.8.0
 beautifulsoup4==4.10.0
 lxml==4.6.4
-python-dotenv==0.19.1
 requests==2.26.0
 tqdm==4.62.3
 datadog==0.42.0


### PR DESCRIPTION
No longer used. I meant to get rid of this earlier
but forgot. Dependabot triggered a reminder when it tried
to update the dependency.

https://github.com/quacs/quacs/pull/717