### PR TITLE
Add course titles to prerequisites and add corequisites

### DIFF
--- a/scrapers/prerequisites_graph/main.py
+++ b/scrapers/prerequisites_graph/main.py
@@ -12,12 +12,12 @@ import argparse
 from typing import Dict, List, TypedDict
 
 
-class Adj(TypedDict):
+class CoursePrereqs(TypedDict):
     title: str
     prereqs: List[str]
 
 
-def sem_add_courses(sem_dir: str, adj_list: Dict[str, Adj]):
+def sem_add_courses(sem_dir: str, adj_list: Dict[str, CoursePrereqs]):
     """
     Using the semester in the `sem_dir` directory,
     update the graph in `adj_list`.
@@ -81,7 +81,7 @@ def generate(semester_data_path: str):
 
     # Map from course ID to title and prereqs.
     # This is an adjacency list.
-    adj_list: Dict[str, Adj] = dict()
+    adj_list: Dict[str, CoursePrereqs] = dict()
 
     # List of semester paths
     sem_dirs = list(

--- a/scrapers/prerequisites_graph/main.py
+++ b/scrapers/prerequisites_graph/main.py
@@ -9,9 +9,15 @@ import os
 import functools
 import operator
 import argparse
+from typing import Dict, List, TypedDict
 
 
-def sem_add_courses(sem_dir: str, adj_list):
+class Adj(TypedDict):
+    title: str
+    prereqs: List[str]
+
+
+def sem_add_courses(sem_dir: str, adj_list: Dict[str, Adj]):
     """
     Using the semester in the `sem_dir` directory,
     update the graph in `adj_list`.
@@ -36,27 +42,13 @@ def sem_add_courses(sem_dir: str, adj_list):
                 sem_prereqs[str(course["sections"][0]["crn"])]
             )
 
-            # Only add courses that have prereqs, to make the json smaller
-            if len(prereqs) == 0:
-                # This course has no prereqs,
-                # but may have had prereqs in the past,
-                # so try to delete the course.
-                # Semester iteration order is from older to newer,
-                # so this should work okay.
-                adj_list.pop(course_id, None)
-            else:
-                # Since this is a dict and iteration order is from older to newer,
-                # this should have the most updated data.
-                # NOTE: Some sections have different prereqs.
-                # This is more uncommon than common,
-                # so hopefully this will never be an issue.
-                adj_list[course_id] = {
-                    "title": course["title"],
-                    "prereqs": prereqs,
-                }
+            adj_list[course_id] = {
+                "title": course["title"],
+                "prereqs": prereqs,
+            }
 
 
-def get_prereq_course_ids(prereqs):
+def get_prereq_course_ids(prereqs) -> List[str]:
     """
     Given the `prereqs` of a course in the format of the courses.json file,
     return a list of all prerequisite courses mentioned.
@@ -65,7 +57,7 @@ def get_prereq_course_ids(prereqs):
 
     prereqs = prereqs.get("prerequisites", prereqs)
     try:
-        typ = prereqs["type"]
+        typ: str = prereqs["type"]
     except KeyError:
         return []
     if typ == "course":
@@ -78,6 +70,7 @@ def get_prereq_course_ids(prereqs):
                 )
             )
         )
+    return []
 
 
 def generate(semester_data_path: str):
@@ -88,7 +81,7 @@ def generate(semester_data_path: str):
 
     # Map from course ID to title and prereqs.
     # This is an adjacency list.
-    adj_list = dict()
+    adj_list: Dict[str, Adj] = dict()
 
     # List of semester paths
     sem_dirs = list(

--- a/site/src/components/sections/SectionInfo.vue
+++ b/site/src/components/sections/SectionInfo.vue
@@ -15,6 +15,7 @@
               $store.getters['prerequisites/getPriorCourses'](),
           }"
           >{{ course }}
+          {{ courseName(course) }}
         </span>
       </template>
       <template v-if="prerequisiteData.cross_list_courses">
@@ -29,6 +30,7 @@
               $store.getters['prerequisites/getPriorCourses'](),
           }"
           >{{ course }}
+          {{ courseName(course) }}
         </span>
       </template>
       <br />
@@ -98,6 +100,14 @@ export default class SectionInfo extends Vue {
 
   get courseCode(): string {
     return `${this.section.subj} ${this.section.crse}`;
+  }
+
+  get courseName(): (course: string) => string {
+    return (course: string): string => {
+      return course
+        ? this.$store.state.prereqGraph[course.replace("-", " ")]?.title ?? ""
+        : "";
+    };
   }
 }
 </script>

--- a/site/src/components/sections/SectionInfo.vue
+++ b/site/src/components/sections/SectionInfo.vue
@@ -3,6 +3,20 @@
     <b-modal :id="'section-info' + section.crn" :title="modalTitle">
       <div class="font-weight-bold">Prerequisites:</div>
       <span v-html="formatPrerequisites(section.crn) || 'None'"></span>
+      <template v-if="prerequisiteData.corequisites">
+        <div class="font-weight-bold">Corequisites:</div>
+        <span
+          v-for="course in prerequisiteData.corequisites"
+          :key="course"
+          class="course"
+          :class="{
+            takenCourse:
+              course.replace(' ', '-') in
+              $store.getters['prerequisites/getPriorCourses'](),
+          }"
+          >{{ course }}
+        </span>
+      </template>
       <template v-if="prerequisiteData.cross_list_courses">
         <div class="font-weight-bold">Cross listed with:</div>
         <span

--- a/site/src/utilities.ts
+++ b/site/src/utilities.ts
@@ -245,7 +245,13 @@ function getPrerequisiteFormatHtml(
     } else {
       output += `<span style="color: var(--not-taken-course);">`;
     }
+
+    const title = store.state.prereqGraph[prereq.course]?.title;
     output += prereq.course.replace(" ", "-");
+    if (title) {
+      output += " " + title;
+    }
+
     output += "</span>";
   } else {
     if (!topLevel) {
@@ -354,7 +360,12 @@ export function trackEvent(event_value: string, event_type: string): void {
     return;
   }
 
-  umami.trackEvent(event_value, event_type);
+  try {
+    umami.trackEvent(event_value, event_type);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e);
+  }
 }
 
 export function trackView(url: string, referrer?: string): void {
@@ -364,5 +375,10 @@ export function trackView(url: string, referrer?: string): void {
     return;
   }
 
-  umami.trackView(url, referrer);
+  try {
+    umami.trackView(url, referrer);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e);
+  }
 }


### PR DESCRIPTION
Adds course names to info modal. I did however decide not to add it to the graph part because it just became a mess and I dont think it is really needed

![image](https://user-images.githubusercontent.com/18558130/142096199-8a09d463-268a-4380-8f40-5e5f99de379c.png)
One note, this screenshot does not have all the courses labeled because not all the data existed in the prerequisite graph before this pr. But now I add courses with no prerequisites to that file so that we have the names of the courses 

![image](https://user-images.githubusercontent.com/18558130/142096690-8282e68b-262c-41f8-8c71-c70498170e17.png)

I also added some try catches around some umami code. It was causing me issues locally and anyway we dont want the website to break if umami is down so this solves that problem