### PR TITLE
sis-scraper: adjust behavior in get_semesters_to_scrape

### DIFF
--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -248,6 +248,7 @@ async def scrape_term(term):
     courses = list(filter(lambda dept: len(dept["courses"]) > 0, courses))
     # If semester is too far in the future, don't do anything.
     if len(courses) == 0:
+        print("Semester is empty - skipping it!")
         return
 
     # Ensure data/{term} exists

--- a/scrapers/sis_scraper/util.py
+++ b/scrapers/sis_scraper/util.py
@@ -51,16 +51,20 @@ def get_semesters_to_scrape():
     # roll back to nearest RPI start month
     # We can get away with not needing time deltas since we can't wrap years
     # due to January being a semester start month
+    # If we're in a start month, back up a bit so we don't miss data from the immediate prior semester
+    # This is important for fall -> winter enrichment and spring -> arch transitions
+    if month in RPI_SEMESTER_MONTH_OFFSETS:
+        month -= 1
     while month not in RPI_SEMESTER_MONTH_OFFSETS:
         month -= 1
 
     date = datetime.date(date.year, month, 1)
     semesters.append(date)
 
-    for _ in range(2):
-        # Now roll forward until we find two more semesters
+    for _ in range(len(RPI_SEMESTER_MONTH_OFFSETS) - 1):
+        # Now roll forward until we find the remaining semesters
         # Since the maximum amount of days in a month is 31,
-        # we can add 32 to guarentee a jump, since timedelta has no months option :(
+        # we need to add 32 to guarentee a jump, since timedelta has no months option :(
         date += datetime.timedelta(days=32)
         # Avoid overflowing months, just reset the day back to 1
         date = date.replace(day=1)


### PR DESCRIPTION
This resolves an issue noticed where fall 2021 stopped
being scraped because we're now in December and Winter Enrichment starts in December.
This also would've been observed in spring -> arch transitions as the spring ends
in May and Arch starts in May.

To address this, if our starting month is in RPI_SEMESTER_MONTH_OFFSETS,
just rollback to the previous semester.