### PR TITLE
sis-scraper: avoid infinite loop if run in January

### DIFF
--- a/scrapers/sis_scraper/util.py
+++ b/scrapers/sis_scraper/util.py
@@ -52,11 +52,16 @@ def get_semesters_to_scrape():
     # We can get away with not needing time deltas since we can't wrap years
     # due to January being a semester start month
     # If we're in a start month, back up a bit so we don't miss data from the immediate prior semester
-    # This is important for fall -> winter enrichment and spring -> arch transitions
+    # This is important for back-to-back semester transitions as otherwise we'd miss
+    # the final weeks worth of data
     if month in RPI_SEMESTER_MONTH_OFFSETS:
         month -= 1
     while month not in RPI_SEMESTER_MONTH_OFFSETS:
         month -= 1
+        # Wrap around if necessary
+        if month == 0:
+            month = max(RPI_SEMESTER_MONTH_OFFSETS)
+            break
 
     date = datetime.date(date.year, month, 1)
     semesters.append(date)


### PR DESCRIPTION
This is an oversight from the previous commit which fixed
back-to-back semester scraping. If we are in January,
the previous code would 'roll back' a month to 0
and then proceed in an infinite loop going negative
until interrupted or killed by the 6 hour timeout
on Github Actions.

To fix this, simply set the starting month to the
maximum in the offsets set if we hit 0.