### PR TITLE
conflict_logic: minor improvements and optimizations

### DIFF
--- a/scrapers/sis_scraper/conflict_logic.py
+++ b/scrapers/sis_scraper/conflict_logic.py
@@ -27,7 +27,8 @@ def gen(term, data):
                         divide,
                     )
                     """
-
+    # Sort to ensure deterministic ordering
+    unique_ranges = sorted(unique_ranges)
     MINUTE_GRANULARITY = 1
     NUM_MIN_PER_HOUR = 60 // MINUTE_GRANULARITY
 
@@ -141,15 +142,16 @@ def gen(term, data):
         # This part essentially tries to see if some other bit(s) other than the current one will create a conflict
         # for the conflicting classes in pair_list
         # If there is, we can safely discard this bit.
-        pairs_to_delete = set()
+        redundant_pairs = 0
         for pair in pair_list:
             table1 = sem_conflict_dict[pair[0]]
             table2 = sem_conflict_dict[pair[1]]
             for x in table1:
                 if x != index1 and x in table2:
-                    pairs_to_delete.add(pair)
+                    redundant_pairs += 1
+                    break
 
-        if len(pairs_to_delete) == len(pair_list):
+        if redundant_pairs == len(pair_list):
             for pair in pair_list:
                 table1 = sem_conflict_dict[pair[0]]
                 table2 = sem_conflict_dict[pair[1]]
@@ -173,7 +175,7 @@ def gen(term, data):
 
     # Compute the proper bit vec length for quacs-rs
     BIT_VEC_SIZE = math.ceil((BIT_VEC_SIZE - len(unnecessary_indices)) / 64)
-    with open(f"data/{term}/mod.rs", "w") as f:  # -{os.getenv("CURRENT_TERM")}
+    with open(f"data/{term}/mod.rs", "w") as f:
         f.write(
             """\
 //This file was automatically generated. Please do not modify it directly

--- a/scrapers/sis_scraper/sis_scraper_test.py
+++ b/scrapers/sis_scraper/sis_scraper_test.py
@@ -100,6 +100,7 @@ def bitpack_section_conflict(bp1, bp2):
 # courses. This compares the bitpack results to the results from neieve comparision
 def test_conflict_bitpacks():
     for term in os.listdir("data"):
+        print(f"Testing {term}")
         bitpacks = get_bitpacks(f"data/{term}/mod.rs")
         sections = []
         with open(f"data/{term}/courses.json") as f:
@@ -119,7 +120,18 @@ def test_conflict_bitpacks():
                 bitpack_conflict = bitpack_section_conflict(
                     bitpacks[section1["crn"]], bitpacks[section2["crn"]]
                 )
-            assert naive_conflict == bitpack_conflict
+            if naive_conflict != bitpack_conflict:
+                print(
+                    f"""ERROR!
+                    Naive algorithm says that {section1["crn"]} and {section2["crn"]} {"do" if naive_conflict else "do not"} have a conflict.
+                    ... but bitpacks indicate they {"do" if bitpack_conflict else "do not"}!
+
+                    Section 1 data:\n{section1}
+                    --------------------------
+                    Section 2 data:\n{section2}
+                    """
+                )
+                exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix 1:
Ben pointed something out to me in the code that ended up
being a non-issue. However, upon closer inspection, I found
we were needlessly building a set when we could just count
the number of redundant pairs and break early to avoid counting
duplicates

Fix 2:
I've been noticing some non-determinism in the bitpacks for the semesters.
Its very minor in fall2021 and spring2022. However, in Winter Enrichment 2021
its been very common. I believe I've isolated it to the unique_ranges set.
It's being iterated through and since sets have an undefined ordering
this could be the source of the problem. This is a regression caused
by 79d91d75c023b08599298a02f549346ff63af81c

Fix 3:
Minor improvement to the sis_scraper_test to report back information
about failures instead of simply printing AssertionError. It currently
still doesn't work for the winter enrichment term but that will come
soon.