### PR TITLE
 Show registration restrictions on section cards and clean up cross-listing and co-requisite display

### DIFF
--- a/site/src/components/sections/SectionInfo.vue
+++ b/site/src/components/sections/SectionInfo.vue
@@ -14,7 +14,7 @@
             <div class="font-weight-bold">{{ mode.display }}:</div>
             <ul>
               <li
-                v-for="course in prerequisiteData.corequisites"
+                v-for="course in prerequisiteData[mode.internal]"
                 :key="course"
                 class="course"
                 :class="{
@@ -29,6 +29,63 @@
             </ul>
           </template>
         </div>
+      </template>
+      <template v-if="prerequisiteData.restrictions">
+        <template
+          v-for="type in [
+            { internal: 'level', display: 'levels' },
+            { internal: 'campus', display: 'campuses' },
+            { internal: 'classification', display: 'classes' },
+            { internal: 'degree', display: 'degrees' },
+            { internal: 'college', display: 'schools' },
+            { internal: 'major', display: 'majors' },
+            {
+              internal: 'field_of_study',
+              display: 'fields of study (major or minor)',
+            },
+          ]"
+        >
+          <div :key="type">
+            <template v-if="prerequisiteData.restrictions[type.internal]">
+              <template
+                v-if="prerequisiteData.restrictions[type.internal].must_be"
+              >
+                <div class="font-weight-bold">
+                  Restricted to the following {{ type.display }}:
+                </div>
+                <ul>
+                  <li
+                    v-for="restriction in prerequisiteData.restrictions[
+                      type.internal
+                    ].must_be"
+                    :key="restriction"
+                    class="type.internal"
+                  >
+                    {{ restriction }}
+                  </li>
+                </ul>
+              </template>
+              <template
+                v-if="prerequisiteData.restrictions[type.internal].may_not_be"
+              >
+                <div class="font-weight-bold">
+                  Not allowed for the following {{ type.display }}:
+                </div>
+                <ul>
+                  <li
+                    v-for="restriction in prerequisiteData.restrictions[
+                      type.internal
+                    ].may_not_be"
+                    :key="restriction"
+                    class="restriction"
+                  >
+                    {{ restriction }}
+                  </li>
+                </ul>
+              </template>
+            </template>
+          </div>
+        </template>
       </template>
       <div class="font-weight-bold">Dates Offered:</div>
       <div>

--- a/site/src/components/sections/SectionInfo.vue
+++ b/site/src/components/sections/SectionInfo.vue
@@ -2,254 +2,33 @@
   <div>
     <b-modal :id="'section-info' + section.crn" :title="modalTitle">
       <div class="font-weight-bold">Prerequisites:</div>
-      <ul v-html="formatPrerequisites(section.crn) || 'None'"></ul>
-      <template v-if="prerequisiteData.corequisites">
-        <div class="font-weight-bold">Corequisites:</div>
-        <ul>
-          <li
-            v-for="course in prerequisiteData.corequisites"
-            :key="course"
-            class="course"
-            :class="{
-              takenCourse:
-                course.replace(' ', '-') in
-                $store.getters['prerequisites/getPriorCourses'](),
-            }"
-          >
-            {{ course }}
-            {{ courseName(course) }}
-          </li>
-        </ul>
-      </template>
-      <template v-if="prerequisiteData.cross_list_courses">
-        <div class="font-weight-bold">Cross listed with:</div>
-        <ul>
-          <li
-            v-for="course in prerequisiteData.cross_list_courses"
-            :key="course"
-            class="course"
-            :class="{
-              takenCourse:
-                course.replace(' ', '-') in
-                $store.getters['prerequisites/getPriorCourses'](),
-            }"
-          >
-            {{ course }}
-            {{ courseName(course) }}
-          </li>
-        </ul>
-      </template>
-      <template v-if="prerequisiteData.restrictions">
-        <template v-if="prerequisiteData.restrictions.level">
-          <template v-if="prerequisiteData.restrictions.level.must_be">
-            <div class="font-weight-bold">
-              Restricted to the following levels:
-            </div>
+      <span v-html="formatPrerequisites(section.crn) || 'None'"></span>
+      <template
+        v-for="mode in [
+          { internal: 'corequisites', display: 'Corequisites' },
+          { internal: 'cross_list_courses', display: 'Cross-listed with' },
+        ]"
+      >
+        <div :key="mode">
+          <template v-if="prerequisiteData[mode.internal]">
+            <div class="font-weight-bold">{{ mode.display }}:</div>
             <ul>
               <li
-                v-for="level in prerequisiteData.restrictions.level.must_be"
-                :key="level"
-                class="level"
+                v-for="course in prerequisiteData.corequisites"
+                :key="course"
+                class="course"
+                :class="{
+                  takenCourse:
+                    course.replace(' ', '-') in
+                    $store.getters['prerequisites/getPriorCourses'](),
+                }"
               >
-              {{ level }}
+                {{ course }}
+                {{ courseName(course) }}
               </li>
             </ul>
           </template>
-          <template v-if="prerequisiteData.restrictions.level.may_not_be">
-            <div class="font-weight-bold">
-              Not allowed for the following levels:
-            </div>
-            <ul>
-              <li
-                v-for="level in prerequisiteData.restrictions.level.may_not_be"
-                :key="level"
-                class="level"
-              >
-              {{ level }}
-              </li>
-            </ul>
-          </template>
-        </template>
-        <template v-if="prerequisiteData.restrictions.campus">
-          <template v-if="prerequisiteData.restrictions.campus.must_be">
-            <div class="font-weight-bold">
-              Restricted to the following campuses:
-            </div>
-            <ul>
-              <li
-                v-for="campus in prerequisiteData.restrictions.campus.must_be"
-                :key="campus"
-                class="campus"
-              >
-              {{ campus }}
-              </li>
-            </ul>
-          </template>
-          <template v-if="prerequisiteData.restrictions.campus.may_not_be">
-            <div class="font-weight-bold">
-              Not allowed for the following campuses:
-            </div>
-            <ul>
-              <li
-                v-for="campus in prerequisiteData.restrictions.campus.may_not_be"
-                :key="campus"
-                class="campus"
-              >
-              {{ campus }}
-              </li>
-            </ul>
-          </template>
-        </template>
-        <template v-if="prerequisiteData.restrictions.classification">
-          <template v-if="prerequisiteData.restrictions.classification.must_be">
-            <div class="font-weight-bold">
-              Restricted to the following classes:
-            </div>
-            <ul>
-              <li
-                v-for="classification in prerequisiteData.restrictions.classification.must_be"
-                :key="classification"
-                class="classification"
-              >
-              {{ classification }}
-              </li>
-            </ul>
-          </template>
-          <template v-if="prerequisiteData.restrictions.classification.may_not_be">
-            <div class="font-weight-bold">
-              Not allowed for the following classes:
-            </div>
-            <ul>
-              <li
-                v-for="classification in prerequisiteData.restrictions.classification.may_not_be"
-                :key="classification"
-                class="classification"
-              >
-              {{ classification }}
-              </li>
-            </ul>
-          </template>
-        </template>
-        <template v-if="prerequisiteData.restrictions.degree">
-          <template v-if="prerequisiteData.restrictions.degree.must_be">
-            <div class="font-weight-bold">
-              Restricted to the following degrees:
-            </div>
-            <ul>
-              <li
-                v-for="degree in prerequisiteData.restrictions.degree.must_be"
-                :key="degree"
-                class="degree"
-              >
-              {{ degree }}
-              </li>
-            </ul>
-          </template>
-          <template v-if="prerequisiteData.restrictions.degree.may_not_be">
-            <div class="font-weight-bold">
-              Not allowed for the following degrees:
-            </div>
-            <ul>
-              <li
-                v-for="degree in prerequisiteData.restrictions.degree.may_not_be"
-                :key="degree"
-                class="degree"
-              >
-              {{ degree }}
-              </li>
-            </ul>
-          </template>
-        </template>
-        <template v-if="prerequisiteData.restrictions.college">
-          <template v-if="prerequisiteData.restrictions.college.must_be">
-            <div class="font-weight-bold">
-              Restricted to the following schools:
-            </div>
-            <ul>
-              <li
-                v-for="college in prerequisiteData.restrictions.college.must_be"
-                :key="college"
-                class="college"
-              >
-              {{ college }}
-              </li>
-            </ul>
-          </template>
-          <template v-if="prerequisiteData.restrictions.college.may_not_be">
-            <div class="font-weight-bold">
-              Not allowed for the following schools:
-            </div>
-            <ul>
-              <li
-                v-for="college in prerequisiteData.restrictions.college.may_not_be"
-                :key="college"
-                class="college"
-              >
-              {{ college }}
-              </li>
-            </ul>
-          </template>
-        </template>
-        <template v-if="prerequisiteData.restrictions.major">
-          <template v-if="prerequisiteData.restrictions.major.must_be">
-            <div class="font-weight-bold">
-              Restricted to the following majors:
-            </div>
-            <ul>
-              <li
-                v-for="major in prerequisiteData.restrictions.major.must_be"
-                :key="major"
-                class="major"
-              >
-              {{ major }}
-              </li>
-            </ul>
-          </template>
-          <template v-if="prerequisiteData.restrictions.major.may_not_be">
-            <div class="font-weight-bold">
-              Not allowed for the following majors:
-            </div>
-            <ul>
-              <li
-                v-for="major in prerequisiteData.restrictions.major.may_not_be"
-                :key="major"
-                class="major"
-              >
-              {{ major }}
-              </li>
-            </ul>
-          </template>
-        </template>
-        <template v-if="prerequisiteData.restrictions.field_of_study">
-          <template v-if="prerequisiteData.restrictions.field_of_study.must_be">
-            <div class="font-weight-bold">
-              Restricted to the following fields of study (major or minor):
-            </div>
-            <ul>
-              <li
-                v-for="field_of_study in prerequisiteData.restrictions.field_of_study.must_be"
-                :key="field_of_study"
-                class="field_of_study"
-              >
-              {{ field_of_study }}
-              </li>
-            </ul>
-          </template>
-          <template v-if="prerequisiteData.restrictions.field_of_study.may_not_be">
-            <div class="font-weight-bold">
-              Not allowed for the following fields of study (major or minor):
-            </div>
-            <ul>
-              <li
-                v-for="field_of_study in prerequisiteData.restrictions.field_of_study.may_not_be"
-                :key="field_of_study"
-                class="field_of_study"
-              >
-              {{ field_of_study }}
-              </li>
-            </ul>
-          </template>
-        </template>
+        </div>
       </template>
       <div class="font-weight-bold">Dates Offered:</div>
       <div>

--- a/site/src/components/sections/SectionInfo.vue
+++ b/site/src/components/sections/SectionInfo.vue
@@ -2,39 +2,255 @@
   <div>
     <b-modal :id="'section-info' + section.crn" :title="modalTitle">
       <div class="font-weight-bold">Prerequisites:</div>
-      <span v-html="formatPrerequisites(section.crn) || 'None'"></span>
+      <ul v-html="formatPrerequisites(section.crn) || 'None'"></ul>
       <template v-if="prerequisiteData.corequisites">
         <div class="font-weight-bold">Corequisites:</div>
-        <span
-          v-for="course in prerequisiteData.corequisites"
-          :key="course"
-          class="course"
-          :class="{
-            takenCourse:
-              course.replace(' ', '-') in
-              $store.getters['prerequisites/getPriorCourses'](),
-          }"
-          >{{ course }}
-          {{ courseName(course) }}
-        </span>
+        <ul>
+          <li
+            v-for="course in prerequisiteData.corequisites"
+            :key="course"
+            class="course"
+            :class="{
+              takenCourse:
+                course.replace(' ', '-') in
+                $store.getters['prerequisites/getPriorCourses'](),
+            }"
+          >
+            {{ course }}
+            {{ courseName(course) }}
+          </li>
+        </ul>
       </template>
       <template v-if="prerequisiteData.cross_list_courses">
         <div class="font-weight-bold">Cross listed with:</div>
-        <span
-          v-for="course in prerequisiteData.cross_list_courses"
-          :key="course"
-          class="course"
-          :class="{
-            takenCourse:
-              course.replace(' ', '-') in
-              $store.getters['prerequisites/getPriorCourses'](),
-          }"
-          >{{ course }}
-          {{ courseName(course) }}
-        </span>
+        <ul>
+          <li
+            v-for="course in prerequisiteData.cross_list_courses"
+            :key="course"
+            class="course"
+            :class="{
+              takenCourse:
+                course.replace(' ', '-') in
+                $store.getters['prerequisites/getPriorCourses'](),
+            }"
+          >
+            {{ course }}
+            {{ courseName(course) }}
+          </li>
+        </ul>
       </template>
-      <br />
-      <br />
+      <template v-if="prerequisiteData.restrictions">
+        <template v-if="prerequisiteData.restrictions.level">
+          <template v-if="prerequisiteData.restrictions.level.must_be">
+            <div class="font-weight-bold">
+              Restricted to the following levels:
+            </div>
+            <ul>
+              <li
+                v-for="level in prerequisiteData.restrictions.level.must_be"
+                :key="level"
+                class="level"
+              >
+              {{ level }}
+              </li>
+            </ul>
+          </template>
+          <template v-if="prerequisiteData.restrictions.level.may_not_be">
+            <div class="font-weight-bold">
+              Not allowed for the following levels:
+            </div>
+            <ul>
+              <li
+                v-for="level in prerequisiteData.restrictions.level.may_not_be"
+                :key="level"
+                class="level"
+              >
+              {{ level }}
+              </li>
+            </ul>
+          </template>
+        </template>
+        <template v-if="prerequisiteData.restrictions.campus">
+          <template v-if="prerequisiteData.restrictions.campus.must_be">
+            <div class="font-weight-bold">
+              Restricted to the following campuses:
+            </div>
+            <ul>
+              <li
+                v-for="campus in prerequisiteData.restrictions.campus.must_be"
+                :key="campus"
+                class="campus"
+              >
+              {{ campus }}
+              </li>
+            </ul>
+          </template>
+          <template v-if="prerequisiteData.restrictions.campus.may_not_be">
+            <div class="font-weight-bold">
+              Not allowed for the following campuses:
+            </div>
+            <ul>
+              <li
+                v-for="campus in prerequisiteData.restrictions.campus.may_not_be"
+                :key="campus"
+                class="campus"
+              >
+              {{ campus }}
+              </li>
+            </ul>
+          </template>
+        </template>
+        <template v-if="prerequisiteData.restrictions.classification">
+          <template v-if="prerequisiteData.restrictions.classification.must_be">
+            <div class="font-weight-bold">
+              Restricted to the following classes:
+            </div>
+            <ul>
+              <li
+                v-for="classification in prerequisiteData.restrictions.classification.must_be"
+                :key="classification"
+                class="classification"
+              >
+              {{ classification }}
+              </li>
+            </ul>
+          </template>
+          <template v-if="prerequisiteData.restrictions.classification.may_not_be">
+            <div class="font-weight-bold">
+              Not allowed for the following classes:
+            </div>
+            <ul>
+              <li
+                v-for="classification in prerequisiteData.restrictions.classification.may_not_be"
+                :key="classification"
+                class="classification"
+              >
+              {{ classification }}
+              </li>
+            </ul>
+          </template>
+        </template>
+        <template v-if="prerequisiteData.restrictions.degree">
+          <template v-if="prerequisiteData.restrictions.degree.must_be">
+            <div class="font-weight-bold">
+              Restricted to the following degrees:
+            </div>
+            <ul>
+              <li
+                v-for="degree in prerequisiteData.restrictions.degree.must_be"
+                :key="degree"
+                class="degree"
+              >
+              {{ degree }}
+              </li>
+            </ul>
+          </template>
+          <template v-if="prerequisiteData.restrictions.degree.may_not_be">
+            <div class="font-weight-bold">
+              Not allowed for the following degrees:
+            </div>
+            <ul>
+              <li
+                v-for="degree in prerequisiteData.restrictions.degree.may_not_be"
+                :key="degree"
+                class="degree"
+              >
+              {{ degree }}
+              </li>
+            </ul>
+          </template>
+        </template>
+        <template v-if="prerequisiteData.restrictions.college">
+          <template v-if="prerequisiteData.restrictions.college.must_be">
+            <div class="font-weight-bold">
+              Restricted to the following schools:
+            </div>
+            <ul>
+              <li
+                v-for="college in prerequisiteData.restrictions.college.must_be"
+                :key="college"
+                class="college"
+              >
+              {{ college }}
+              </li>
+            </ul>
+          </template>
+          <template v-if="prerequisiteData.restrictions.college.may_not_be">
+            <div class="font-weight-bold">
+              Not allowed for the following schools:
+            </div>
+            <ul>
+              <li
+                v-for="college in prerequisiteData.restrictions.college.may_not_be"
+                :key="college"
+                class="college"
+              >
+              {{ college }}
+              </li>
+            </ul>
+          </template>
+        </template>
+        <template v-if="prerequisiteData.restrictions.major">
+          <template v-if="prerequisiteData.restrictions.major.must_be">
+            <div class="font-weight-bold">
+              Restricted to the following majors:
+            </div>
+            <ul>
+              <li
+                v-for="major in prerequisiteData.restrictions.major.must_be"
+                :key="major"
+                class="major"
+              >
+              {{ major }}
+              </li>
+            </ul>
+          </template>
+          <template v-if="prerequisiteData.restrictions.major.may_not_be">
+            <div class="font-weight-bold">
+              Not allowed for the following majors:
+            </div>
+            <ul>
+              <li
+                v-for="major in prerequisiteData.restrictions.major.may_not_be"
+                :key="major"
+                class="major"
+              >
+              {{ major }}
+              </li>
+            </ul>
+          </template>
+        </template>
+        <template v-if="prerequisiteData.restrictions.field_of_study">
+          <template v-if="prerequisiteData.restrictions.field_of_study.must_be">
+            <div class="font-weight-bold">
+              Restricted to the following fields of study (major or minor):
+            </div>
+            <ul>
+              <li
+                v-for="field_of_study in prerequisiteData.restrictions.field_of_study.must_be"
+                :key="field_of_study"
+                class="field_of_study"
+              >
+              {{ field_of_study }}
+              </li>
+            </ul>
+          </template>
+          <template v-if="prerequisiteData.restrictions.field_of_study.may_not_be">
+            <div class="font-weight-bold">
+              Not allowed for the following fields of study (major or minor):
+            </div>
+            <ul>
+              <li
+                v-for="field_of_study in prerequisiteData.restrictions.field_of_study.may_not_be"
+                :key="field_of_study"
+                class="field_of_study"
+              >
+              {{ field_of_study }}
+              </li>
+            </ul>
+          </template>
+        </template>
+      </template>
       <div class="font-weight-bold">Dates Offered:</div>
       <div>
         {{ section.timeslots[0].dateStart }} -

--- a/site/src/components/sections/SectionInfo.vue
+++ b/site/src/components/sections/SectionInfo.vue
@@ -3,6 +3,7 @@
     <b-modal :id="'section-info' + section.crn" :title="modalTitle">
       <div class="font-weight-bold">Prerequisites:</div>
       <span v-html="formatPrerequisites(section.crn) || 'None'"></span>
+      <br /><br />
       <template
         v-for="mode in [
           { internal: 'corequisites', display: 'Corequisites' },

--- a/site/src/utilities.ts
+++ b/site/src/utilities.ts
@@ -259,7 +259,9 @@ function getPrerequisiteFormatHtml(
       .map((childPrereq) =>
         getPrerequisiteFormatHtml(priorCourses, childPrereq, false)
       )
-      .join(` ${prereq.type} `);
+      .join(
+              prereq.type == "and" ? " and "+(topLevel ? "<br />" : "") : " or "
+      );
 
     if (!topLevel) {
       output += ")";

--- a/site/src/utilities.ts
+++ b/site/src/utilities.ts
@@ -259,9 +259,7 @@ function getPrerequisiteFormatHtml(
       .map((childPrereq) =>
         getPrerequisiteFormatHtml(priorCourses, childPrereq, false)
       )
-      .join(
-              prereq.type == "and" ? " and "+(topLevel ? "<br />" : "") : " or "
-      );
+      .join(prereq.type);
 
     if (!topLevel) {
       output += ")";

--- a/site/src/utilities.ts
+++ b/site/src/utilities.ts
@@ -259,7 +259,7 @@ function getPrerequisiteFormatHtml(
       .map((childPrereq) =>
         getPrerequisiteFormatHtml(priorCourses, childPrereq, false)
       )
-      .join(prereq.type);
+      .join(` ${prereq.type} `);
 
     if (!topLevel) {
       output += ")";


### PR DESCRIPTION
* Shows when sections require you to be in a specific major/degree to register (e.g. almost all of GSAS) or to *not* be in a specific major/degree (e.g. ARTS-2230).
* Shows when sections require you to be in a certain class (e.g. freshman-specific IHSS) or to be of graduate standing.
* Puts cross-listings and co-requisites in a `<ul>` which looks much nicer than before, which was a list without any delimiter.
* Adds a line break on AND prerequisites to make it easier to read.
### Example card:
![new_card](https://user-images.githubusercontent.com/116031952/201010370-456c0b17-73e7-4343-aa21-8001ac80e050.png)