### PR TITLE
scroll bars have color now

### DIFF
--- a/site/src/assets/styles/colors.css
+++ b/site/src/assets/styles/colors.css
@@ -55,38 +55,57 @@
   /* Calendar colors -- used to distinguish classes */
   --num-calendar-colors: 7;
 
+
+
   /* Calendar class color 0 */
   --calendar-bg-color-0: #ffe9cf;
   --calendar-border-color-0: #ff9332;
   --calendar-text-color-0: #000;
+  --calendar-sb-track-color-0: var(--calendar-bg-color-0);
+  --calendar-sb-thumb-color-0: var(--calendar-border-color-0);
+
+  /* scroll bar colors will default to whatever the background and border colors are,
+  but are also available to be overridden by themes */
 
   /* Calendar class color 1 */
   --calendar-bg-color-1: #ffd4df;
   --calendar-border-color-1: #ff2066;
   --calendar-text-color-1: #000;
+  --calendar-sb-track-color-1: var(--calendar-bg-color-1);
+  --calendar-sb-thumb-color-1: var(--calendar-border-color-1);
 
   /* Calendar class color 2 */
   --calendar-bg-color-2: #ceeffc;
   --calendar-border-color-2: #00aff2;
   --calendar-text-color-2: #000;
+  --calendar-sb-track-color-2: var(--calendar-bg-color-2);
+  --calendar-sb-thumb-color-2: var(--calendar-border-color-2);
 
   /* Calendar class color 3 */
   --calendar-bg-color-3: #fff4d0;
   --calendar-border-color-3: #ffcb45;
   --calendar-text-color-3: #000;
+  --calendar-sb-track-color-3: var(--calendar-bg-color-3);
+  --calendar-sb-thumb-color-3: var(--calendar-border-color-3);
 
   /* Calendar class color 4 */
   --calendar-bg-color-4: #dcf7da;
   --calendar-border-color-4: #48da58;
   --calendar-text-color-4: #000;
+  --calendar-sb-track-color-4: var(--calendar-bg-color-4);
+  --calendar-sb-thumb-color-4: var(--calendar-border-color-4);
 
   /* Calendar class color 5 */
   --calendar-bg-color-5: #f7e2f7;
   --calendar-border-color-5: #d373da;
   --calendar-text-color-5: #000;
+  --calendar-sb-track-color-5: var(--calendar-bg-color-5);
+  --calendar-sb-thumb-color-5: var(--calendar-border-color-5);
 
   /* Calendar class color 6 */
   --calendar-bg-color-6: #ede6df;
   --calendar-border-color-6: #a48363;
   --calendar-text-color-6: #000;
+  --calendar-sb-track-color-6: var(--calendar-bg-color-6);
+  --calendar-sb-thumb-color-6: var(--calendar-border-color-6);
 }

--- a/site/src/assets/styles/colors.css
+++ b/site/src/assets/styles/colors.css
@@ -55,8 +55,6 @@
   /* Calendar colors -- used to distinguish classes */
   --num-calendar-colors: 7;
 
-
-
   /* Calendar class color 0 */
   --calendar-bg-color-0: #ffe9cf;
   --calendar-border-color-0: #ff9332;

--- a/site/src/components/Calendar.vue
+++ b/site/src/components/Calendar.vue
@@ -333,7 +333,6 @@ $dayFontSize: 0.8em;
 .calendar-event {
   display: block;
   box-sizing: border-box;
-  // border-top: 1px solid #e7e7e7 !important; //temp fix for the borders not showing
   border-right: 1px solid #e7e7e7 !important;
   position: absolute;
   //height: 20%;

--- a/site/src/components/Calendar.vue
+++ b/site/src/components/Calendar.vue
@@ -44,6 +44,7 @@
                 color: colors(session.section.crn).text,
                 scrollbarColor:
                   colors(session.section.crn).sbThumb +
+                  ' ' +
                   colors(session.section.crn).sbTrack,
                 '--sb-track-color': colors(session.section.crn).sbTrack,
                 '--sb-thumb-color': colors(session.section.crn).sbThumb,

--- a/site/src/components/Calendar.vue
+++ b/site/src/components/Calendar.vue
@@ -42,6 +42,11 @@
                 backgroundColor: colors(session.section.crn).bg,
                 borderColor: colors(session.section.crn).border,
                 color: colors(session.section.crn).text,
+                scrollbarColor:
+                  colors(session.section.crn).sbThumb +
+                  colors(session.section.crn).sbTrack,
+                '--sb-track-color': colors(session.section.crn).sbTrack,
+                '--sb-thumb-color': colors(session.section.crn).sbThumb,
               }"
             >
               <div class="event-text">
@@ -253,6 +258,8 @@ export default class Calendar extends Vue {
         bg: "var(--calendar-bg-color-" + colorIdx + ")",
         border: "var(--calendar-border-color-" + colorIdx + ")",
         text: "var(--calendar-text-color-" + colorIdx + ")",
+        sbTrack: "var(--calendar-sb-track-color-" + colorIdx + ")",
+        sbThumb: "var(--calendar-sb-thumb-color-" + colorIdx + ")",
       };
     };
   }
@@ -325,7 +332,7 @@ $dayFontSize: 0.8em;
 .calendar-event {
   display: block;
   box-sizing: border-box;
-  border-top: 1px solid #e7e7e7 !important; //temp fix for the borders not showing
+  // border-top: 1px solid #e7e7e7 !important; //temp fix for the borders not showing
   border-right: 1px solid #e7e7e7 !important;
   position: absolute;
   //height: 20%;
@@ -345,6 +352,16 @@ $dayFontSize: 0.8em;
     height: 100%;
     overflow-y: auto;
   }
+}
+
+div.calendar-event ::-webkit-scrollbar {
+  background: var(--sub-track-color);
+  width: 8px;
+}
+
+div.calendar-event ::-webkit-scrollbar-thumb {
+  background: var(--sb-thumb-color);
+  border-radius: 10vw; /* just a high number to keep it round */
 }
 </style>
 

--- a/site/src/components/Calendar.vue
+++ b/site/src/components/Calendar.vue
@@ -355,7 +355,7 @@ $dayFontSize: 0.8em;
 }
 
 div.calendar-event ::-webkit-scrollbar {
-  background: var(--sub-track-color);
+  background: var(--sb-track-color);
   width: 8px;
 }
 


### PR DESCRIPTION
works on macos with firefox, chrome, and safari. I'd assume it works fine on other stuff too or just doesn't change it. 
Mobile seems to just ignore it, atleast on iOS with those same browsers.

Also added CSS variables to colors.css so that the scroll bars can be customized with themes, by default it just links back to the background and border colors so it can adjust on its own. 

I suppose it fixes #32 ? Not entirely sure if that's what you all had in mind for it or not.

also turned off the 'temp fix for borders not showing up' on the calendar events, not really sure what that was supposed to be fixing but I think it looks better without it ? especially since now the left border can go up all the way instead of having a weird triangle cut out of it at the top.