### PR TITLE
themeable card borders

### DIFF
--- a/site/src/assets/styles/colors.css
+++ b/site/src/assets/styles/colors.css
@@ -7,6 +7,7 @@
   --card-body-background: #fff;
   --card-body-text: #000;
   --card-header-background: #f7f7f7;
+  --card-border-color: #dfdfdf;
   --footer-background: #d3d3d3;
   --navbar-background: #f8f9fa;
   --navbar-unselected-text: rgb(0 0 0 / 50%);
@@ -33,6 +34,7 @@
   --modal-close-x-hover: #000;
   --card-header-hover: #eaeaea;
   --table-text: #212529;
+  --table-border: #dee2e6;
   --course-row-hover: #f0f0f0;
   --conflict-row: #ff6060;
   --conflict-row-hover: #ff7b7b;

--- a/site/src/assets/styles/global.css
+++ b/site/src/assets/styles/global.css
@@ -17,6 +17,10 @@ body {
   color: var(--card-header-text);
 }
 
+.card {
+  border-color: var(--card-border-color);
+}
+
 .navbar.bg-light {
   background: var(--navbar-background) !important;
 }
@@ -93,6 +97,18 @@ body {
 
 .table {
   color: var(--table-text);
+}
+
+.table-bordered td {
+  border-color: var(--table-border);
+}
+
+.table thead th {
+  border-color: var(--table-border);
+}
+
+.table-bordered {
+  border-color: var(--table-border);
 }
 
 .list-group-item {


### PR DESCRIPTION
just makes it so you can change the color of the borders on the cards with themes more easily. 

It was hard coded before, it looked like maybe it just came from some bootstrap thing maybe ? I couldn't find where it was coming from in any of the quacs files atleast so I figured it wouldn't be an issue to just override it. 

It keeps the same default so everything will look the same unless a theme overrides it.

added because the default borders didn't look great with the theme I'm working on.

It will change the color of the tables in the course cards too. I figure since they're already the same just keep it the same ? But wouldn't be too hard to pop that out to its own variable if it seems like it's an issue.