### PR TITLE
Show courses whose credit counts vary by section properly

### DIFF
--- a/site/src/components/CourseCard.vue
+++ b/site/src/components/CourseCard.vue
@@ -197,10 +197,14 @@ export default class CourseCard extends Vue {
   expanded = this.startExpanded ? this.startExpanded : false;
 
   get credMin(): string {
-    var min = 2147483647; // arbitrary large number
-    var max = 0;
-    this.course.sections.forEach((sec) => (min = Math.min(min, sec.credMin)));
-    this.course.sections.forEach((sec) => (max = Math.max(max, sec.credMax)));
+    const min = this.course.sections.reduce(
+      (prev, sec) => Math.min(prev, sec.credMin),
+      Infinity
+    );
+    const max = this.course.sections.reduce(
+      (prev, sec) => Math.max(prev, sec.credMax),
+      -Infinity
+    );
     return min + (min !== max ? "-" + max : "");
   }
 

--- a/site/src/components/CourseCard.vue
+++ b/site/src/components/CourseCard.vue
@@ -197,12 +197,11 @@ export default class CourseCard extends Vue {
   expanded = this.startExpanded ? this.startExpanded : false;
 
   get credMin(): string {
-    return (
-      this.course.sections[0].credMin +
-      (this.course.sections[0].credMin !== this.course.sections[0].credMax
-        ? "-" + this.course.sections[0].credMax
-        : "")
-    );
+    var min = 2147483647; // arbitrary large number
+    var max = 0;
+    this.course.sections.forEach((sec) => (min = Math.min(min, sec.credMin)));
+    this.course.sections.forEach((sec) => (max = Math.max(max, sec.credMax)));
+    return min + (min !== max ? "-" + max : "");
   }
 
   get attributes(): string {


### PR DESCRIPTION
RCOS currently shows as "1 credit" despite the fact that it can be taken for 1-4 credits. This is because the old logic just picked the first section and took the credit information from that. This change accounts for sections having different credit numbers by checking all of them and finding the minimum and the maximum credits this way.

The motivation for this is that I was going to take RCOS at some point last year but I decided against it because I thought it was only 1 credit, even though it wasn't, due to this confusion. I also accounted for this in the Quatalog because it kept annoying me.

Currently, QuACS shows RCOS like this:
![image](https://user-images.githubusercontent.com/116031952/209600730-effb98ef-867e-4090-b88d-0c203ab9160f.png)

This change makes it show RCOS like this:
![image](https://user-images.githubusercontent.com/116031952/209600775-3f1df0ae-37c4-4eac-a8b6-b83cb6219b8c.png)

