### PR TITLE
Unofficial schedule modal fix

### DIFF
--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -345,7 +345,7 @@ async def scrape_terms_list():
                 lambda val : val != '',
                 map(lambda tag : tag["value"],raw_terms)
             ))
-        with open(f"data/terms_in_course_search.json", "w+") as outfile:
+        with open(f"terms_in_course_search.json", "w") as outfile:
             outfile.write('["%s"]' % '","'.join(terms))
 
 async def main():
@@ -359,7 +359,7 @@ async def main():
     ) as session:
         semesters = util.get_semesters_to_scrape()
         await scrape_terms_list()
-"""
+        """
         if sys.argv[-1] == "ALL_YEARS":
             print("Parsing all years")
             for term in os.listdir("data/"):
@@ -373,7 +373,7 @@ async def main():
 
         for semester in semesters:
             await scrape_term(semester)
-"""
+        """
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -359,7 +359,7 @@ async def main():
     ) as session:
         semesters = util.get_semesters_to_scrape()
         await scrape_terms_list()
-        """
+        
         if sys.argv[-1] == "ALL_YEARS":
             print("Parsing all years")
             for term in os.listdir("data/"):
@@ -373,7 +373,6 @@ async def main():
 
         for semester in semesters:
             await scrape_term(semester)
-        """
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -331,6 +331,22 @@ async def scrape_term(term):
         json.dump(prerequisites, outfile, sort_keys=True, indent=2)
     print("Done")
 
+async def scrape_terms_list():
+    global session
+    async with session.get(
+        "https://sis.rpi.edu/rss/bwckschd.p_disp_dyn_sched",
+    ) as request:
+        soup = BeautifulSoup(await request.text())
+        raw_terms = soup.find(
+            "select",
+            {"id": "term_input_id"},
+        ).findAll("option")
+        terms = list(filter(
+                lambda val : val != '',
+                map(lambda tag : tag["value"],raw_terms)
+            ))
+        with open(f"data/terms_in_course_search.json", "w+") as outfile:
+            outfile.write("[%s]" % terms.join(","));
 
 async def main():
     if sys.argv[-1] == "help" or sys.argv[-1] == "--help":
@@ -342,7 +358,8 @@ async def main():
         connector=aiohttp.TCPConnector(limit=5)
     ) as session:
         semesters = util.get_semesters_to_scrape()
-
+        await scrape_terms_list()
+"""
         if sys.argv[-1] == "ALL_YEARS":
             print("Parsing all years")
             for term in os.listdir("data/"):
@@ -356,7 +373,7 @@ async def main():
 
         for semester in semesters:
             await scrape_term(semester)
-
+"""
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -346,7 +346,7 @@ async def scrape_terms_list():
                 map(lambda tag : tag["value"],raw_terms)
             ))
         with open(f"data/terms_in_course_search.json", "w+") as outfile:
-            outfile.write("[%s]" % terms.join(","));
+            outfile.write('["%s"]' % '","'.join(terms))
 
 async def main():
     if sys.argv[-1] == "help" or sys.argv[-1] == "--help":

--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -331,6 +331,7 @@ async def scrape_term(term):
         json.dump(prerequisites, outfile, sort_keys=True, indent=2)
     print("Done")
 
+
 async def scrape_terms_list():
     global session
     async with session.get(
@@ -341,12 +342,12 @@ async def scrape_terms_list():
             "select",
             {"id": "term_input_id"},
         ).findAll("option")
-        terms = list(filter(
-                lambda val : val != '',
-                map(lambda tag : tag["value"],raw_terms)
-            ))
+        terms = list(
+            filter(lambda val: val != "", map(lambda tag: tag["value"], raw_terms))
+        )
         with open(f"terms_in_course_search.json", "w") as outfile:
             outfile.write('["%s"]' % '","'.join(terms))
+
 
 async def main():
     if sys.argv[-1] == "help" or sys.argv[-1] == "--help":
@@ -359,7 +360,7 @@ async def main():
     ) as session:
         semesters = util.get_semesters_to_scrape()
         await scrape_terms_list()
-        
+
         if sys.argv[-1] == "ALL_YEARS":
             print("Parsing all years")
             for term in os.listdir("data/"):
@@ -373,6 +374,7 @@ async def main():
 
         for semester in semesters:
             await scrape_term(semester)
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/site/scripts/build_single.sh
+++ b/site/scripts/build_single.sh
@@ -53,6 +53,7 @@ rm .env
 echo "VUE_APP_CURR_SEM=$CURR_SEMESTER" >>.env
 printf "VUE_APP_SEMS_IN_SEARCH=" >>.env
 cat src/store/data/terms_in_course_search.json >>.env
+echo >>.env
 echo -n "VUE_APP_ALL_SEMS=[" >>.env
 ITER=0
 for directory in $(find src/store/data/semester_data/* -type d -print0 -maxdepth 0 | xargs -0 | sed 's/ /\n/g' | sort -r); do

--- a/site/scripts/build_single.sh
+++ b/site/scripts/build_single.sh
@@ -51,6 +51,8 @@ echo "Got QUACS-data hash: $QUACS_DATA_COMMIT_HASH"
 echo Setting .env file
 rm .env
 echo "VUE_APP_CURR_SEM=$CURR_SEMESTER" >>.env
+printf "VUE_APP_SEMS_IN_SEARCH=" >>.env
+cat src/store/data/terms_in_course_search.json >>.env
 echo -n "VUE_APP_ALL_SEMS=[" >>.env
 ITER=0
 for directory in $(find src/store/data/semester_data/* -type d -print0 -maxdepth 0 | xargs -0 | sed 's/ /\n/g' | sort -r); do

--- a/site/src/components/UnofficialScheduleModal.vue
+++ b/site/src/components/UnofficialScheduleModal.vue
@@ -1,7 +1,7 @@
 <template>
   <b-modal
     title="Course offerings are not official!"
-    :visible="false"
+    :visible="!semsInSearch.includes(currentSem)"
     centered
     size="xl"
     :hide-footer="!acceptedThatScheduleIsUnofficial"
@@ -12,9 +12,9 @@
     hide-header-close
   >
     <span>
-      QuACS is currently based off of a pre-release schedule for the spring
-      semester. Course offerings and associated faculty are subject to change,
-      and prerequisite checking is not available.
+      QuACS is currently based off of a pre-release schedule for this semester.
+      Course offerings and associated faculty are heavily subject to change, and
+      prerequisite checking is not available.
     </span>
     <br />
     <br />
@@ -48,6 +48,10 @@ export default class UnofficialScheduleModal extends Vue {
 
   get currentSem(): string {
     return process.env.VUE_APP_CURR_SEM;
+  }
+
+  get semsInSearch(): string[] {
+    return process.env.VUE_APP_SEMS_IN_SEARCH.split(",");
   }
 }
 </script>

--- a/site/src/components/UnofficialScheduleModal.vue
+++ b/site/src/components/UnofficialScheduleModal.vue
@@ -51,7 +51,7 @@ export default class UnofficialScheduleModal extends Vue {
   }
 
   get semsInSearch(): string[] {
-    return process.env.VUE_APP_SEMS_IN_SEARCH.split(",");
+    return process.env.VUE_APP_SEMS_IN_SEARCH;
   }
 }
 </script>

--- a/site/src/components/UnofficialScheduleModal.vue
+++ b/site/src/components/UnofficialScheduleModal.vue
@@ -24,10 +24,10 @@
       schedule.</b-form-checkbox
     >
     <br />
-    <span
-      >(Please click the checkbox to accept the warning and continue to the
-      website)</span
-    >
+    <span>
+      (Please click the checkbox to accept the warning and continue to the
+      website)
+    </span>
   </b-modal>
 </template>
 


### PR DESCRIPTION
The unofficial schedule warning will show up when the upcoming semesters have not shown up in the list in https://sis.rpi.edu/rss/bwckschd.p_disp_dyn_sched yet. The way this is done:
1) Scrape course search page
2) Put the list of terms in `terms_in_course_search.json`
3) The build script puts the list into an environment variable `VUE_APP_SEMS_IN_SEARCH`
4) `UnofficialScheduleModal.vue` reads this env variable and checks if the current term is in that list. If it is, don't display, and if it isn't, then display
See also this pull request in quacs-data: https://github.com/quacs/quacs-data/pull/10, which creates that file. The scraper crashes when the file doesn't already exist.