### PR TITLE
Fix cypress (for now)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Run tests
         working-directory: ./site
+        env:
+          TERM: dumb
         run: |
           yarn test:serve &
           until $(curl --silent --fail http://localhost:8080/summer2021 | grep QuACS --silent); do printf '.'; sleep 1; done

--- a/site/tests/e2e/specs/department.js
+++ b/site/tests/e2e/specs/department.js
@@ -25,7 +25,7 @@ describe("Test department page", () => {
             .first()
             .within(() => {
               cy.containsOne("01-15982");
-              cy.containsOne("Uzma Mushtaque, Shianne Hulbert");
+              cy.containsOne("Uzma Mushtaque, Shianne M. Hulbert");
               cy.containsOne("05/24 - 08/20");
               cy.containsOne("4/30 seats available");
               cy.getOne(".time-cell-M").containsOne("10:30a-12:10p");

--- a/site/tests/e2e/support/index.js
+++ b/site/tests/e2e/support/index.js
@@ -20,12 +20,11 @@ export const SEMESTER = "202105";
 
 export const SCHOOLS = {
   Architecture: 2,
-  "Information Technology and Web Science": 1,
-  Engineering: 10,
-  "Management and Technology": 1,
-  Science: 11,
+  Engineering: 9,
+  "Management and Technology": 2,
+  Science: 9,
   "Humanities, Arts, and Social Sciences": 13,
-  "Interdisciplinary and Other": 5,
+  "Interdisciplinary and Other": 1,
 };
 
 beforeEach(() => {


### PR DESCRIPTION
Edited the data to reflect what is currently displayed on https://quacs.com/summer2021, and double-checked that it is accurate to SIS. Cypress tests work now.