### PR TITLE
Scrape terms from 1998 to 2008

### DIFF
--- a/scrapers/sis_scraper/main.py
+++ b/scrapers/sis_scraper/main.py
@@ -76,7 +76,7 @@ async def get_section_information(section_url):
         for seat_type in seating[1:]:
             kind = seat_type.find("th").text
             capacity, actual, remaining = tuple(
-                int(x.text) for x in seat_type.findAll("td")
+                int(x.text.replace(u'\xa0','0')) for x in seat_type.findAll("td")
             )
 
             if kind == "Seats":
@@ -348,6 +348,16 @@ async def main():
             for term in os.listdir("data/"):
                 if term not in semesters:
                     semesters.append(term)
+        elif sys.argv[-1] == "OLD_YEARS":
+            print("Parsing pre-2008 years only")
+            # weird special case:
+            # 199805 = first half summer, 199807 = second half
+            # all other summers just put both in XXXX05
+            # also, 199801 is not in SIS
+            semesters = ["199805","199807","199809"]
+            for year in range(1999,2008):
+                for term in ['01','05','09']:
+                    semesters.append(str(year)+str(term))
         elif len(sys.argv[-1]) == 6:
             print(f"Parsing {sys.argv[-1]} only")
             semesters = [sys.argv[-1]]

--- a/site/scripts/build_single.sh
+++ b/site/scripts/build_single.sh
@@ -54,6 +54,10 @@ echo "VUE_APP_CURR_SEM=$CURR_SEMESTER" >>.env
 echo -n "VUE_APP_ALL_SEMS=[" >>.env
 ITER=0
 for directory in $(find src/store/data/semester_data/* -type d -print0 -maxdepth 0 | xargs -0 | sed 's/ /\n/g' | sort -r); do
+	CATALOG_FILE="$directory/catalog.json"
+	if ! test -f "$CATALOG_FILE"; then
+		echo "{}" > "$CATALOG_FILE"
+	fi
 	if test $ITER -ne 0; then
 		echo -n "," >>.env
 	fi


### PR DESCRIPTION
This fixes the issue where QuACS doesn't build properly if catalog.json doesn't exist by just creating an empty catalog JSON, and fixes an issue in the scraper to allow it to scrape all years from 1998 up (broken cross-list and waitlist data had a non-breaking space inside of it, and Python crashed trying to convert the nbsp to int). I have tested the scraper locally and can confirm it works.

There is now a flag in the scraper, `OLD_YEARS`, that makes it scrape the old years only. After they have been scraped once, `ALL_YEARS` also scrapes them.