### PR TITLE
Moar ci updates

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js for use with actions
         uses: actions/setup-node@v3
         with:
-          node-version:  16.x
+          node-version:  18.x
 
       - name: Checkout branch
         uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Checkout site repo
         uses: actions/checkout@v3

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -27,5 +27,5 @@ jobs:
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
         run: |
-          npm install -g @lhci/cli@0.4.x
+          npm install -g @lhci/cli@0.11.0
           lhci autorun --collect.staticDistDir=site/

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Setup Node.js for use with actions
         uses: actions/setup-node@v3
         with:
-          node-version:  16.x
+          node-version:  18.x
 
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Setup Node.js for use with actions
         uses: actions/setup-node@v3
         with:
-          node-version:  16.x
+          node-version:  18.x
 
       - name: Checkout branch
         uses: actions/checkout@v3
@@ -32,7 +32,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install pip requirements
         run: |

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install pip requirements
         run: |
@@ -71,7 +71,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install pip requirements
         run: |
@@ -133,7 +133,7 @@ jobs:
   #     - name: Set up Python
   #       uses: actions/setup-python@v4
   #       with:
-  #         python-version: '3.10'
+  #         python-version: '3.11'
 
   #     - name: Set up Rust
   #       uses: actions-rs/toolchain@v1
@@ -170,7 +170,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install pip requirements
         run: |
@@ -197,7 +197,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install pip requirements
         run: |
@@ -224,7 +224,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install pip requirements
         run: |
@@ -258,7 +258,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install pip requirements
         run: |
@@ -285,7 +285,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Intall pip requirements
         run: |
@@ -409,7 +409,7 @@ jobs:
   #     - name: Set up python
   #       uses: actions/setup-python@v4
   #       with:
-  #         python-version: "3.10"
+  #         python-version: "3.11"
 
   #     - name: Install pip requirements
   #       run: |

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -159,33 +159,33 @@ jobs:
   #         name: degree_requirements
   #         path: degree-planner/*.json
 
-  scrape-hass-pathways:
-    name: Scrape HASS pathways
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    steps:
-      - name: Checkout branch
-        uses: actions/checkout@v3
+  # scrape-hass-pathways:
+  #   name: Scrape HASS pathways
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 1
+  #   steps:
+  #     - name: Checkout branch
+  #       uses: actions/checkout@v3
 
-      - name: Set up python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
+  #     - name: Set up python
+  #       uses: actions/setup-python@v4
+  #       with:
+  #         python-version: '3.11'
 
-      - name: Install pip requirements
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r scrapers/requirements.txt
+  #     - name: Install pip requirements
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install -r scrapers/requirements.txt
 
-      - name: Scrape HASS pathways
-        working-directory: ./scrapers
-        run: python3 hass_pathways_scraper/main.py > hass_pathways.json
+  #     - name: Scrape HASS pathways
+  #       working-directory: ./scrapers
+  #       run: python3 hass_pathways_scraper/main.py > hass_pathways.json
 
-      - name: Upload data
-        uses: actions/upload-artifact@v3
-        with:
-          name: hass_pathways
-          path: scrapers/hass_pathways.json
+  #     - name: Upload data
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: hass_pathways
+  #         path: scrapers/hass_pathways.json
 
   scrape-faculty:
     name: Scrape faculty
@@ -308,10 +308,11 @@ jobs:
     needs:
       - scrape-courses-and-prerequisites
       - scrape-faculty
-      - scrape-hass-pathways
+      #- scrape-hass-pathways
       - scrape-prereq-graph
       - scrape-catalog
       - scrape-csci-topics
+      - scrape-transfer
     if: |
       always()
       && contains(needs.scrape-courses-and-prerequisites.result,'success')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Setup Node.js for use with actions
         uses: actions/setup-node@v3
         with:
-          node-version:  16.x
+          node-version:  18.x
 
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/site/scripts/build_single.sh
+++ b/site/scripts/build_single.sh
@@ -3,6 +3,7 @@
 # This script builds a single semester (stored in $CURR_SEMESTER).  It relies on some setup
 # from build_entry.sh (namely setting up one-time dependencies like Umami and quacs-data)
 # so it should never be called on its own.
+export NODE_OPTIONS=--openssl-legacy-provider # needed because OpenSSL deprecated hash used in Webpack 4
 
 ROOT_DIRECTORY=$(pwd)
 


### PR DESCRIPTION
1. bumped Node.JS to 18.x LTS branch (from 16.x LTS) -- 16.x support is ending in 5 months
2. bumped python from 3.10 to 3.11
3. bumped lhci/cli so lighthouse works under new node
4. disabled hass pathway scraper since its broken (outputs empty JSON)
5. made commit-changes wait on scrape-transfer to complete (failure is okay) to ensure transfer scraping will make it into commit