### PR TITLE
Add SIS catalog scraper

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -358,8 +358,9 @@ jobs:
 
           # Merge SIS catalog + hard_coded + csci_topics data into the final values
           for directory in $(find semester_data/* -type d  | grep -v "hard_coded" | xargs -0); do
-            jq -a -s '.[0] * .[1]' "$directory/sis_catalog.json" "$directory/catalog.json" > "$directory/temp_catalog.json"
+            jq -a -s '.[0] * .[1]' "$directory/catalog_sis.json" "$directory/catalog.json" > "$directory/temp_catalog.json"
             mv "$directory/temp_catalog.json" "$directory/catalog.json"
+            rm "$directory/catalog_sis.json"
             truncate -s -1 "$directory/catalog.json" #jq adds a newline at the end of the file that we dont want
             for merge_data in {"hard_coded","csci_topics"}; do
               if [ -d "$directory/$merge_data" ]; then

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -356,8 +356,11 @@ jobs:
 
           cd data
 
-          # Merge hard_coded + csci_topics data into the final values
+          # Merge SIS catalog + hard_coded + csci_topics data into the final values
           for directory in $(find semester_data/* -type d  | grep -v "hard_coded" | xargs -0); do
+            jq -a -s '.[0] * .[1]' "$directory/sis_catalog.json" "$directory/catalog.json" > "$directory/temp_catalog.json"
+            mv "$directory/temp_catalog.json" "$directory/catalog.json"
+            truncate -s -1 "$directory/catalog.json" #jq adds a newline at the end of the file that we dont want
             for merge_data in {"hard_coded","csci_topics"}; do
               if [ -d "$directory/$merge_data" ]; then
                 if [ -f "$directory/$merge_data/catalog.json" ]; then

--- a/scrapers/catalog_scraper/main.py
+++ b/scrapers/catalog_scraper/main.py
@@ -97,6 +97,7 @@ def get_course_data(course_ids: List[str]) -> Dict:
                 "crse": crse,
                 "name": course.xpath("./content/name/text()")[0].strip(),
                 "description": get_catalog_description(fields, course_name),
+                "source": "Acalog",
             }
 
     return data

--- a/scrapers/csci_topics_scraper/main.py
+++ b/scrapers/csci_topics_scraper/main.py
@@ -91,6 +91,7 @@ def parse_term(courses):
         else:
             name = course_title[2:]
         entry["name"] = " ".join(name).title()
+        entry["source"] = "CSCI topics"
 
         crses = course_title[1].split("/")
         for crse in crses:


### PR DESCRIPTION
Scrapes course descriptions from https://sis.rpi.edu/rss/bwckctlg.p_display_courses?term_in=202309&one_subj=CSCI&sel_crse_strt=0000&sel_crse_end=9999&sel_subj=&sel_levl=&sel_schd=&sel_coll=&sel_divs=&sel_dept=&sel_attr= .

The original catalog scraper is left alone, and this SIS catalog data is used as a fallback when the Acalog catalog has no data for a course. The motivation for this is that RPI is really dragging its feet at releasing the new catalog, and there are a couple new courses with SIS descriptions but without catalog descriptions, [BIOL-1016](https://sis.rpi.edu/rss/bwckctlg.p_disp_course_detail?cat_term_in=202309&subj_code_in=BIOL&crse_numb_in=1016) and [CHEM-4750](https://sis.rpi.edu/rss/bwckctlg.p_disp_course_detail?cat_term_in=202309&subj_code_in=CHEM&crse_numb_in=4750).