### PR TITLE
Disable SSL validation in CSCI topics scraper

### DIFF
--- a/scrapers/csci_topics_scraper/main.py
+++ b/scrapers/csci_topics_scraper/main.py
@@ -102,7 +102,7 @@ def parse_term(courses):
 async def main():
     global session
     async with aiohttp.ClientSession(
-        connector=aiohttp.TCPConnector(limit=5)
+        connector=aiohttp.TCPConnector(limit=5, ssl=False)
     ) as session:
         filenames = await get_topics_txts()
 


### PR DESCRIPTION
Some aiohttp update broke SSL validation so now the Goldschmidt scraper is broken. Here is a fix.