### PR TITLE
Disable CSCI topics scraper

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -312,7 +312,7 @@ jobs:
       #- scrape-hass-pathways
       - scrape-prereq-graph
       - scrape-catalog
-      - scrape-csci-topics
+      # - scrape-csci-topics
       # - scrape-transfer
     if: |
       always()


### PR DESCRIPTION
The `https://www.cs.rpi.edu/~goldsd/docs/` page, which used to be an open access directory listing, is now 403. This breaks the scraper. This PR disables it.