### PR TITLE
Deleting a courseset should delete all the courses

### DIFF
--- a/site/src/store/modules/schedule.ts
+++ b/site/src/store/modules/schedule.ts
@@ -91,12 +91,12 @@ export default class Schedule extends VuexModule {
     if (Object.keys(this.courseSets[this.currentTerm]).length <= 1) {
       return false;
     }
-    this.context.commit("deleteCourseSet", p);
     if (this.currentCourseSet === p.name) {
       this.context.dispatch("switchCurrentCourseSet", {
         name: Object.keys(this.courseSets[this.currentTerm])[0],
       });
     }
+    this.context.commit("deleteCourseSet", p);
     return true;
   }
 


### PR DESCRIPTION
Before:
https://github.com/user-attachments/assets/07ec8581-f06c-4be5-87cd-ef9d7b69385b

After:
https://github.com/user-attachments/assets/b6083efa-3ff4-474b-aa53-00406425442b


Related to #767 

Deleteing a courseset should delete all the courses in the worker. The function deleted the course set first, so the other function doesnt know the courses that its suppose to be deleted. This leads to a disabled vue view and the worker showing available schedules.